### PR TITLE
Add VT compatibility improvements (st reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Built for the [HackberryPi Zero](https://github.com/ZitaoTech/Hackberry-Pi_Zero)
 | Binary (with 59K-glyph font) | 2.8 MB | 2.8 MB |
 | Runtime dependencies | none | libxcb, libxcb-shm, libxcb-xkb, libxkbcommon, libxcb-imdkit |
 | Build time | < 1s | < 1s |
-| Source | 5,488 lines across 11 files |  |
+| Source | 6,113 lines across 11 files |  |
 
 ## Benchmarks
 
@@ -226,9 +226,9 @@ epoll event loop (single-threaded, dynamic timeout)
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `src/vt.zig` | 1,238 | VT parser state machine + action executor, SIMD ASCII fast path, UTF-8 bulk path |
+| `src/vt.zig` | 1,621 | VT parser state machine + action executor, SIMD ASCII fast path, UTF-8 bulk path |
 | `src/backend/x11.zig` | 950 | XCB window, double-buffered SHM, XKB + XIM (lazy init), ConfigureNotify coalescing |
-| `src/term.zig` | 822 | Cell grid with row_map indirection, O(1) dirty flag, scroll, erase, TrueColor sparse maps |
+| `src/term.zig` | 989 | Cell grid with row_map indirection, O(1) dirty flag, scroll, erase, BCE, TrueColor sparse maps |
 | `src/main.zig` | 559 | Event loop, frame limiter, signal/timer setup, PTY drain, write buffering, render orchestration |
 | `src/input.zig` | 527 | Keymap (US/JP), evdev code translation, modifier handling |
 | `src/render.zig` | 389 | Pixel rendering with comptime scaling (BGRA32/RGB565/RGB24), memcpy row duplication |
@@ -245,13 +245,14 @@ epoll event loop (single-threaded, dynamic timeout)
 | Sequence | Name | Description |
 |----------|------|-------------|
 | `CSI n A` | CUU | Cursor up |
-| `CSI n B` | CUD | Cursor down |
-| `CSI n C` | CUF | Cursor forward |
+| `CSI n B/e` | CUD/VPR | Cursor down |
+| `CSI n C/a` | CUF/HPR | Cursor forward |
 | `CSI n D` | CUB | Cursor back |
 | `CSI n E` | CNL | Cursor next line |
 | `CSI n F` | CPL | Cursor preceding line |
-| `CSI n G` | CHA | Cursor horizontal absolute |
+| `CSI n G/`` | CHA/HPA | Cursor horizontal absolute |
 | `CSI n;m H/f` | CUP | Cursor position |
+| `CSI n I` | CHT | Cursor forward tabulation |
 | `CSI n J` | ED | Erase display (0: below, 1: above, 2/3: all) |
 | `CSI n K` | EL | Erase line (0: right, 1: left, 2: all) |
 | `CSI n L` | IL | Insert lines |
@@ -259,16 +260,27 @@ epoll event loop (single-threaded, dynamic timeout)
 | `CSI n P` | DCH | Delete characters |
 | `CSI n X` | ECH | Erase characters |
 | `CSI n @` | ICH | Insert characters |
+| `CSI n Z` | CBT | Cursor backward tabulation |
 | `CSI n b` | REP | Repeat preceding graphic character |
 | `CSI n S` | SU | Scroll up |
 | `CSI n T` | SD | Scroll down |
 | `CSI n d` | VPA | Vertical position absolute |
+| `CSI n g` | TBC | Tab clear (0: current, 3: all) |
 | `CSI t;b r` | DECSTBM | Set scroll region (resets cursor to home) |
-| `CSI s` | | Save cursor position (no private marker) |
-| `CSI u` | | Restore cursor position (no private marker) |
+| `CSI s` | | Save cursor position |
+| `CSI u` | | Restore cursor position |
+| `CSI 5 n` | DSR | Device status report (OK) |
 | `CSI 6 n` | DSR | Device status report (cursor position) |
 | `CSI c` | DA1 | Device attributes (reports VT220) |
+| `CSI > c` | DA2 | Secondary device attributes |
+| `CSI ! p` | DECSTR | Soft terminal reset |
+| `CSI Ps SP q` | DECSCUSR | Set cursor style |
+| `CSI Ps t` | XTWINOPS | Window operations (silently accepted) |
+| `CSI 4 h/l` | IRM | Insert/replace mode |
+| `CSI 20 h/l` | LNM | Linefeed/newline mode |
 | `CSI ... m` | SGR | Select graphic rendition (see below) |
+
+All CSI private markers (`?`, `>`, `<`, `=`) are correctly parsed. Unknown private-marker sequences are silently ignored.
 
 ### SGR (Select Graphic Rendition)
 
@@ -279,11 +291,17 @@ epoll event loop (single-threaded, dynamic timeout)
 | 2 | Dim |
 | 3 | Italic |
 | 4 | Underline |
+| 5, 6 | Blink |
 | 7 | Reverse video |
+| 8 | Invisible |
+| 9 | Strikethrough |
 | 22 | Normal intensity |
 | 23 | Not italic |
 | 24 | Not underline |
+| 25 | Not blink |
 | 27 | Not reverse |
+| 28 | Not invisible |
+| 29 | Not strikethrough |
 | 30-37 | Foreground color (standard) |
 | 38;5;n | Foreground 256-color |
 | 38;2;r;g;b | Foreground 24-bit TrueColor |
@@ -300,28 +318,41 @@ epoll event loop (single-threaded, dynamic timeout)
 | Mode | Name | Description |
 |------|------|-------------|
 | `?1` | DECCKM | Application cursor keys |
+| `?6` | DECOM | Origin mode |
 | `?7` | DECAWM | Auto-wrap mode |
 | `?25` | DECTCEM | Cursor visible |
 | `?47` | | Alternate screen buffer |
 | `?1047` | | Alternate screen buffer |
+| `?1048` | | Save/restore cursor |
 | `?1049` | | Alternate screen + save/restore cursor |
-| `?2004` | | Bracketed paste mode (flag only) |
+| `?2004` | | Bracketed paste mode |
+| `?2026` | | Synchronized update |
+| `?1000-1006` | | Mouse tracking modes (silently accepted) |
+| `?1004` | | Focus events (silently accepted) |
 
 ### Escape sequences
 
 | Sequence | Name | Description |
 |----------|------|-------------|
-| `ESC 7` | DECSC | Save cursor |
-| `ESC 8` | DECRC | Restore cursor |
+| `ESC 7` | DECSC | Save cursor + attributes + charset |
+| `ESC 8` | DECRC | Restore cursor + attributes + charset |
 | `ESC D` | IND | Index (line feed, scrolls at bottom) |
+| `ESC E` | NEL | Next line |
+| `ESC H` | HTS | Horizontal tab stop |
 | `ESC M` | RI | Reverse index |
+| `ESC Z` | DECID | Identify terminal |
 | `ESC c` | RIS | Full reset |
+| `ESC =` | DECKPAM | Application keypad mode |
+| `ESC >` | DECKPNM | Normal keypad mode |
+| `ESC ( 0` | | G0 charset = DEC Special Graphics (line drawing) |
+| `ESC ( B` | | G0 charset = US ASCII |
+| `ESC # 8` | DECALN | Screen alignment test |
 
 ## Tested applications
 
 The following applications have been verified working under Xvfb integration tests:
 
-vim, nano, micro, less, bat, top, btop, man, git (log/diff/status), eza, tree, ripgrep, python3 REPL, fish (completions, history, Ctrl+C, Ctrl+L)
+vim, nano, micro, less, bat, top, btop, man, git (log/diff/status), eza, tree, ripgrep, python3 REPL, fish (completions, history, Ctrl+C, Ctrl+L), Claude Code (Anthropic CLI)
 
 ## Limitations
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zt,
-    .version = "0.1.0",
+    .version = "0.2.2",
     .fingerprint = 0xc36136a6af00f24b,
     .paths = .{
         "build.zig",

--- a/src/term.zig
+++ b/src/term.zig
@@ -8,7 +8,7 @@ pub const Cell = struct {
     bg: u8 = 0,
     attrs: Attrs = .{},
 
-    pub const Attrs = packed struct(u8) {
+    pub const Attrs = packed struct(u16) {
         bold: bool = false,
         italic: bool = false,
         underline: bool = false,
@@ -16,11 +16,29 @@ pub const Cell = struct {
         dim: bool = false,
         wide: bool = false,
         wide_dummy: bool = false,
-        _pad: u1 = 0,
+        blink: bool = false,
+        invisible: bool = false,
+        strikethrough: bool = false,
+        _pad: u6 = 0,
     };
 };
 
 const default_cell: Cell = .{};
+
+pub const CharsetType = enum { us_ascii, dec_graphics };
+
+/// Translate a codepoint through the DEC Special Graphics charset.
+pub fn translateCharset(cp: u21, cs: CharsetType) u21 {
+    if (cs != .dec_graphics) return cp;
+    if (cp < 0x60 or cp > 0x7E) return cp;
+    const table = [_]u21{
+        0x25C6, 0x2592, 0x2409, 0x240C, 0x240D, 0x240A, 0x00B0, 0x00B1, // 0x60-0x67: ◆▒␉␌␍␊°±
+        0x2424, 0x240B, 0x2518, 0x2510, 0x250C, 0x2514, 0x253C, 0x23BA, // 0x68-0x6F: ␤␋┘┐┌└┼⎺
+        0x23BB, 0x2500, 0x23BC, 0x23BD, 0x251C, 0x2524, 0x2534, 0x252C, // 0x70-0x77: ⎻─⎼⎽├┤┴┬
+        0x2502, 0x2264, 0x2265, 0x03C0, 0x2260, 0x00A3, 0x00B7, // 0x78-0x7E: │≤≥π≠£·
+    };
+    return table[cp - 0x60];
+}
 
 pub const Term = struct {
     const Self = @This();
@@ -77,6 +95,39 @@ pub const Term = struct {
     sync_update: bool = false,
     has_truecolor_cells: bool = false,
 
+    // Deferred wrap (VT100 CURSOR_WRAPNEXT)
+    wrap_next: bool = false,
+
+    // Tab stops (settable, per-column)
+    tabs: []bool = &.{},
+
+    // Insert/Replace mode (IRM, CSI 4h/4l)
+    insert_mode: bool = false,
+
+    // Linefeed/Newline mode (LNM, CSI 20h/20l)
+    linefeed_mode: bool = false,
+
+    // Character set support (VT100)
+    charset: u2 = 0, // Active charset index (0=G0, 1=G1, 2=G2, 3=G3)
+    charsets: [4]CharsetType = .{ .us_ascii, .us_ascii, .us_ascii, .us_ascii },
+
+    // Keypad mode
+    deckpam: bool = false,
+
+    // Origin mode (DECOM, DECSET ?6)
+    origin_mode: bool = false,
+
+    // Cursor style (DECSCUSR)
+    cursor_style: u8 = 0,
+
+    // Saved cursor state (DECSC/DECRC — saves attrs + charset like st)
+    saved_attrs: Cell.Attrs = .{},
+    saved_fg: u8 = 7,
+    saved_bg: u8 = 0,
+    saved_charset: u2 = 0,
+    saved_wrap_next: bool = false,
+    saved_origin_mode: bool = false,
+
     pub fn init(allocator: Allocator, cols: u32, rows: u32) !Self {
         const total = @as(usize, cols) * @as(usize, rows);
         const cells = try allocator.alloc(Cell, total);
@@ -92,6 +143,12 @@ pub const Term = struct {
         const bg_rgb = try allocator.alloc(?[3]u8, total);
         @memset(bg_rgb, null);
 
+        // Initialize tab stops every 8 columns
+        const tabs = try allocator.alloc(bool, cols);
+        for (0..cols) |c| {
+            tabs[c] = (c % 8 == 0) and c > 0;
+        }
+
         return Self{
             .allocator = allocator,
             .cols = cols,
@@ -102,6 +159,7 @@ pub const Term = struct {
             .scroll_bottom = rows -| 1,
             .fg_rgb = fg_rgb,
             .bg_rgb = bg_rgb,
+            .tabs = tabs,
         };
     }
 
@@ -109,6 +167,7 @@ pub const Term = struct {
         self.allocator.free(self.cells);
         self.allocator.free(self.row_map);
         self.dirty.deinit();
+        if (self.tabs.len > 0) self.allocator.free(self.tabs);
         if (self.alt_cells) |alt| self.allocator.free(alt);
         if (self.alt_row_map) |arm| self.allocator.free(arm);
         if (self.alt_dirty != null) {
@@ -307,6 +366,12 @@ pub const Term = struct {
         self.scroll_top = 0;
         self.scroll_bottom = new_rows -| 1;
 
+        // Resize tab stops
+        if (self.tabs.len > 0) self.allocator.free(self.tabs);
+        self.tabs = try self.allocator.alloc(bool, new_cols);
+        for (0..new_cols) |c| {
+            self.tabs[c] = (c % 8 == 0) and c > 0;
+        }
 
         // Clamp cursor
         self.cursor_x = @min(self.cursor_x, new_cols -| 1);
@@ -415,6 +480,7 @@ pub const Term = struct {
     pub fn moveCursorTo(self: *Self, x: u32, y: u32) void {
         self.cursor_x = @min(x, self.cols -| 1);
         self.cursor_y = @min(y, self.rows -| 1);
+        self.wrap_next = false;
     }
 
     pub fn moveCursorRel(self: *Self, dx: i32, dy: i32) void {
@@ -422,6 +488,7 @@ pub const Term = struct {
         const new_y = @as(i64, self.cursor_y) + @as(i64, dy);
         self.cursor_x = @intCast(@as(u32, @intCast(std.math.clamp(new_x, 0, @as(i64, self.cols) - 1))));
         self.cursor_y = @intCast(@as(u32, @intCast(std.math.clamp(new_y, 0, @as(i64, self.rows) - 1))));
+        self.wrap_next = false;
     }
 
     /// Fix wide character boundaries at the edges of an erase/delete range.
@@ -539,6 +606,34 @@ pub const Term = struct {
 
     pub fn carriageReturn(self: *Self) void {
         self.cursor_x = 0;
+        self.wrap_next = false;
+    }
+
+    /// Move cursor to next/previous tab stop. n > 0 = forward, n < 0 = backward.
+    pub fn tputtab(self: *Self, n: i32) void {
+        self.wrap_next = false;
+        const cols = self.cols;
+        var x = self.cursor_x;
+        if (n > 0) {
+            var count: u32 = @intCast(n);
+            while (x < cols and count > 0) {
+                count -= 1;
+                x += 1;
+                while (x < cols and !(x < self.tabs.len and self.tabs[@intCast(x)])) {
+                    x += 1;
+                }
+            }
+        } else if (n < 0) {
+            var count: u32 = @intCast(-n);
+            while (x > 0 and count > 0) {
+                count -= 1;
+                x -= 1;
+                while (x > 0 and !(x < self.tabs.len and self.tabs[@intCast(x)])) {
+                    x -= 1;
+                }
+            }
+        }
+        self.cursor_x = @min(x, cols -| 1);
     }
 
     pub fn setScrollRegion(self: *Self, top: u32, bottom: u32) void {

--- a/src/term.zig
+++ b/src/term.zig
@@ -289,11 +289,10 @@ pub const Term = struct {
         const region_height = bot - top + 1;
         const shift: usize = @min(n, @as(u32, @intCast(region_height)));
 
-        // Clear recycled rows (top `shift` rows become new bottom rows)
+        // Clear recycled rows with BCE
         for (0..shift) |s| {
             const phys = self.row_map[top + s];
-            @memset(self.cells[phys * cols .. (phys + 1) * cols], Cell{});
-            if (self.has_truecolor_cells) self.clearRgbRow(phys);
+            self.bceMemset(phys * cols, (phys + 1) * cols);
         }
 
         // Rotate row_map: moves top rows to bottom in one pass
@@ -320,11 +319,10 @@ pub const Term = struct {
         const region_height = bot - top + 1;
         const shift: usize = @min(n, @as(u32, @intCast(region_height)));
 
-        // Clear recycled rows (bottom `shift` rows become new top rows)
+        // Clear recycled rows with BCE
         for (0..shift) |s| {
             const phys = self.row_map[bot - s];
-            @memset(self.cells[phys * cols .. (phys + 1) * cols], Cell{});
-            if (self.has_truecolor_cells) self.clearRgbRow(phys);
+            self.bceMemset(phys * cols, (phys + 1) * cols);
         }
 
         // Rotate row_map: moves bottom rows to top in one pass
@@ -491,6 +489,24 @@ pub const Term = struct {
         self.wrap_next = false;
     }
 
+    /// Return a blank cell with current background color (BCE — Background Color Erase).
+    /// All erase/scroll/clear operations must use this instead of Cell{}.
+    pub inline fn blankCell(self: *const Self) Cell {
+        return .{ .char = ' ', .fg = self.current_fg, .bg = self.current_bg };
+    }
+
+    /// Fill physical range with blank cells using BCE, including TrueColor bg.
+    fn bceMemset(self: *Self, phys_start: usize, phys_end: usize) void {
+        @memset(self.cells[phys_start..phys_end], self.blankCell());
+        if (self.current_bg_rgb) |rgb| {
+            @memset(self.bg_rgb[phys_start..phys_end], rgb);
+            self.has_truecolor_cells = true;
+        } else {
+            @memset(self.bg_rgb[phys_start..phys_end], null);
+        }
+        @memset(self.fg_rgb[phys_start..phys_end], null);
+    }
+
     /// Fix wide character boundaries at the edges of an erase/delete range.
     fn fixWideBoundaries(self: *Self, logical_start: usize, logical_end: usize) void {
         const cols: usize = self.cols;
@@ -523,44 +539,45 @@ pub const Term = struct {
 
     pub fn eraseDisplay(self: *Self, mode: u8) void {
         const cols: usize = self.cols;
+        const blank = self.blankCell();
         switch (mode) {
             0 => {
                 const start_x = self.cursor_x;
                 const start_y = self.cursor_y;
                 self.fixWideBoundaries(start_y * cols + start_x, @as(usize, self.rows) * cols);
-                // Clear from cursor to end
                 for (start_y..self.rows) |y| {
                     const phys = self.row_map[y];
                     const from: usize = if (y == start_y) start_x else 0;
-                    @memset(self.cells[phys * cols + from .. (phys + 1) * cols], Cell{});
+                    self.bceMemset(phys * cols + from, (phys + 1) * cols);
                 }
                 const logical_start = start_y * cols + start_x;
                 const total = @as(usize, self.rows) * cols;
                 self.markDirtyRange(.{ .start = logical_start, .end = total });
-                self.clearRgbRange(start_y, self.rows, 0);
             },
             1 => {
                 const end_x = self.cursor_x;
                 const end_y = self.cursor_y;
                 self.fixWideBoundaries(0, end_y * cols + end_x + 1);
-                // Clear from start to cursor inclusive
                 for (0..end_y + 1) |y| {
                     const phys = self.row_map[y];
                     const to: usize = if (y == end_y) end_x + 1 else cols;
-                    @memset(self.cells[phys * cols .. phys * cols + to], Cell{});
+                    self.bceMemset(phys * cols, phys * cols + to);
                 }
                 self.markDirtyRange(.{ .start = 0, .end = end_y * cols + end_x + 1 });
-                self.clearRgbRange(0, end_y + 1, 0);
             },
             2, 3 => {
-                // Erase all — reset row_map to identity and memset entire array
                 const total = @as(usize, self.cols) * @as(usize, self.rows);
-                @memset(self.cells[0..total], Cell{});
+                @memset(self.cells[0..total], blank);
                 for (0..self.rows) |i| self.row_map[i] = @intCast(i);
                 self.markDirtyRange(.{ .start = 0, .end = total });
-                self.clearAllRgb();
-                self.has_truecolor_cells = false;
-        
+                // BCE: fill TrueColor arrays with current bg
+                if (self.current_bg_rgb) |rgb| {
+                    @memset(self.bg_rgb[0..total], rgb);
+                    self.has_truecolor_cells = true;
+                } else {
+                    @memset(self.bg_rgb[0..total], null);
+                }
+                @memset(self.fg_rgb[0..total], null);
             },
             else => {},
         }
@@ -576,21 +593,18 @@ pub const Term = struct {
             0 => {
                 const cx: usize = self.cursor_x;
                 self.fixWideBoundaries(row_start + cx, row_start + cols);
-                @memset(self.cells[phys * cols + cx .. (phys + 1) * cols], Cell{});
+                self.bceMemset(phys * cols + cx, (phys + 1) * cols);
                 self.markDirtyRange(.{ .start = row_start + cx, .end = row_start + cols });
-                self.clearRgbPhysRange(phys * cols + cx, (phys + 1) * cols);
             },
             1 => {
                 const cx: usize = self.cursor_x;
                 self.fixWideBoundaries(row_start, row_start + cx + 1);
-                @memset(self.cells[phys * cols .. phys * cols + cx + 1], Cell{});
+                self.bceMemset(phys * cols, phys * cols + cx + 1);
                 self.markDirtyRange(.{ .start = row_start, .end = row_start + cx + 1 });
-                self.clearRgbPhysRange(phys * cols, phys * cols + cx + 1);
             },
             2 => {
-                @memset(self.cells[phys * cols .. (phys + 1) * cols], Cell{});
+                self.bceMemset(phys * cols, (phys + 1) * cols);
                 self.markDirtyRange(.{ .start = row_start, .end = row_start + cols });
-                self.clearRgbPhysRange(phys * cols, (phys + 1) * cols);
             },
             else => {},
         }
@@ -653,13 +667,11 @@ pub const Term = struct {
         const bot: usize = self.scroll_bottom;
         const cy: usize = self.cursor_y;
 
-        // Save physical rows being pushed off the bottom
         var saved: [256]u32 = undefined;
         for (0..count) |s| {
             const phys = self.row_map[bot - s];
             saved[s] = phys;
-            @memset(self.cells[phys * cols .. (phys + 1) * cols], Cell{});
-            self.clearRgbRow(phys);
+            self.bceMemset(phys * cols, (phys + 1) * cols);
         }
 
         // Shift row_map down within [cy, bot]
@@ -684,13 +696,11 @@ pub const Term = struct {
         const bot: usize = self.scroll_bottom;
         const cy: usize = self.cursor_y;
 
-        // Save physical rows being deleted
         var saved: [256]u32 = undefined;
         for (0..count) |s| {
             const phys = self.row_map[cy + s];
             saved[s] = phys;
-            @memset(self.cells[phys * cols .. (phys + 1) * cols], Cell{});
-            self.clearRgbRow(phys);
+            self.bceMemset(phys * cols, (phys + 1) * cols);
         }
 
         // Shift row_map up within [cy, bot]
@@ -726,11 +736,10 @@ pub const Term = struct {
             std.mem.copyForwards(Cell, self.cells[row_base + cx .. row_base + cx + copy_len], self.cells[row_base + cx + count .. row_base + cx + count + copy_len]);
         }
 
-        // Clear rightmost characters
-        @memset(self.cells[row_base + cols - count .. row_base + cols], Cell{});
+        // Clear rightmost characters with BCE
+        self.bceMemset(row_base + cols - count, row_base + cols);
 
         self.markDirtyRange(.{ .start = logical_row_start + cx, .end = logical_row_start + cols });
-        self.clearRgbPhysRange(row_base + cx, row_base + cols);
     }
 
     pub fn insertChars(self: *Self, n: u32) void {
@@ -743,20 +752,17 @@ pub const Term = struct {
         const row_base = phys * cols;
         const logical_row_start = @as(usize, self.cursor_y) * cols;
 
-        // Fix wide character boundaries at insertion point
         self.fixWideBoundaries(logical_row_start + cx, logical_row_start + cx + count);
 
-        // Shift characters right (physical)
         const copy_len = remaining - count;
         if (copy_len > 0) {
             std.mem.copyBackwards(Cell, self.cells[row_base + cx + count .. row_base + cx + count + copy_len], self.cells[row_base + cx .. row_base + cx + copy_len]);
         }
 
-        // Clear inserted characters
-        @memset(self.cells[row_base + cx .. row_base + cx + count], Cell{});
+        // Clear inserted characters with BCE
+        self.bceMemset(row_base + cx, row_base + cx + count);
 
         self.markDirtyRange(.{ .start = logical_row_start + cx, .end = logical_row_start + cols });
-        self.clearRgbPhysRange(row_base + cx, row_base + cols);
     }
 
     pub fn eraseChars(self: *Self, n: u32) void {
@@ -769,12 +775,10 @@ pub const Term = struct {
         const row_base = phys * cols;
         const logical_row_start = @as(usize, self.cursor_y) * cols;
 
-        // Fix wide character boundaries at erase range
         self.fixWideBoundaries(logical_row_start + cx, logical_row_start + cx + count);
-        @memset(self.cells[row_base + cx .. row_base + cx + count], Cell{});
+        self.bceMemset(row_base + cx, row_base + cx + count);
 
         self.markDirtyRange(.{ .start = logical_row_start + cx, .end = logical_row_start + cx + count });
-        self.clearRgbPhysRange(row_base + cx, row_base + cx + count);
     }
 
     /// Clear RGB entries for a physical row (O(1) memset)

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -405,22 +405,23 @@ pub const Parser = struct {
 pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.posix.fd_t) void {
     var i: usize = 0;
     while (i < data.len) {
-        // Fast path: ground state + printable ASCII run
+        // Fast path: ground state + printable ASCII run (US-ASCII charset only, no insert mode)
         // Writes directly to cells[] array, bypassing setCell/handlePrint overhead.
         // Safe because ASCII is never wide and doesn't need TrueColor cleanup.
-        if (parser.state == .ground and data[i] >= 0x20 and data[i] <= 0x7E) {
+        if (parser.state == .ground and data[i] >= 0x20 and data[i] <= 0x7E and
+            term.charsets[term.charset] == .us_ascii and !term.insert_mode)
+        {
             const cols = term.cols;
             while (true) {
                 // Handle printable ASCII run on current line
                 if (i >= data.len or (@as(u32, data[i]) -% 0x20) > 0x5E) break;
-                // Line wrap
-                if (term.cursor_x >= cols) {
+                // Deferred wrap from previous char
+                if (term.wrap_next) {
                     if (term.decawm) {
                         term.cursor_x = 0;
                         term.insertNewline();
-                    } else {
-                        term.cursor_x = cols - 1;
                     }
+                    term.wrap_next = false;
                 }
                 // Bulk write: compute run length that fits on current line
                 const remaining = cols - term.cursor_x;
@@ -484,14 +485,18 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                 term.last_printed_char = @as(u21, data[i + count - 1]);
                 term.cursor_x += count;
                 i += count;
+                // Deferred wrap: if cursor went past right margin, set wrap_next
+                if (term.cursor_x >= cols) {
+                    term.cursor_x = cols - 1;
+                    term.wrap_next = true;
+                }
                 // Inline control character handling — stay in fast path loop
-                // Avoids 58K round-trips through parser.feed() for LF/CR
                 if (i < data.len) {
                     switch (data[i]) {
-                        0x0A, 0x0B, 0x0C => { term.insertNewline(); i += 1; continue; },
+                        0x0A, 0x0B, 0x0C => { term.wrap_next = false; term.insertNewline(); i += 1; continue; },
                         0x0D => { term.carriageReturn(); i += 1; continue; },
-                        0x08 => { if (term.cursor_x > 0) term.cursor_x -= 1; i += 1; continue; },
-                        0x09 => { term.cursor_x = @min(((term.cursor_x / 8) + 1) * 8, cols -| 1); i += 1; continue; },
+                        0x08 => { term.wrap_next = false; if (term.cursor_x > 0) term.cursor_x -= 1; i += 1; continue; },
+                        0x09 => { term.tputtab(1); i += 1; continue; },
                         else => {},
                     }
                 }
@@ -499,10 +504,12 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
             }
             continue;
         }
-        // Medium path: ground state + UTF-8 multi-byte characters
+        // Medium path: ground state + UTF-8 multi-byte characters (US-ASCII charset, no insert mode)
         // Decode directly, bypassing per-byte parser state machine overhead.
         // Non-wide chars written directly to cells[] with batch dirty marking.
-        if (parser.state == .ground and data[i] >= 0xC0 and data[i] < 0xFE) {
+        if (parser.state == .ground and data[i] >= 0xC0 and data[i] < 0xFE and
+            !term.insert_mode)
+        {
             const start_i = i;
             var dirty_run_start: usize = @as(usize, term.cursor_y) * @as(usize, term.cols) + term.cursor_x;
             var dirty_run_end: usize = dirty_run_start;
@@ -540,16 +547,16 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                 }
                 // Non-wide: direct cell write (like ASCII fast path)
                 const cols = term.cols;
-                if (term.cursor_x >= cols) {
+                // Deferred wrap
+                if (term.wrap_next) {
                     // Flush pending dirty before line change
                     if (dirty_run_start < dirty_run_end)
                         term.markDirtyRange(.{ .start = dirty_run_start, .end = dirty_run_end });
                     if (term.decawm) {
                         term.cursor_x = 0;
                         term.insertNewline();
-                    } else {
-                        term.cursor_x = cols - 1;
                     }
+                    term.wrap_next = false;
                     dirty_run_start = @as(usize, term.cursor_y) * @as(usize, cols) + term.cursor_x;
                     dirty_run_end = dirty_run_start;
                 }
@@ -571,7 +578,12 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                 const logical_idx = @as(usize, term.cursor_y) * @as(usize, cols) + term.cursor_x;
                 dirty_run_end = logical_idx + 1;
                 term.last_printed_char = cp;
-                term.cursor_x += 1;
+                if (term.cursor_x + 1 < cols) {
+                    term.cursor_x += 1;
+                } else {
+                    term.cursor_x = cols - 1;
+                    term.wrap_next = true;
+                }
                 i += seq_len;
             }
             // Flush accumulated dirty range
@@ -595,7 +607,7 @@ pub fn executeActionWithFd(action: Action, term: *Term, writer_fd: ?std.posix.fd
         .print => |cp| handlePrint(cp, term),
         .execute => |c| handleControl(c, term),
         .csi_dispatch => |csi| handleCsi(csi, term, writer_fd),
-        .esc_dispatch => |esc| handleEsc(esc, term),
+        .esc_dispatch => |esc| handleEsc(esc, term, writer_fd),
         .osc_dispatch => {},
         .dcs_dispatch => |payload| handleDcsDispatch(payload, writer_fd),
         .none => {},
@@ -691,23 +703,33 @@ fn isWide(cp: u21) bool {
 }
 
 fn handlePrint(cp: u21, term: *Term) void {
-    const wide = isWide(cp);
+    // Apply charset translation (VT100 DEC Graphics)
+    const actual_cp = term_mod.translateCharset(cp, term.charsets[term.charset]);
+    const wide = isWide(actual_cp);
 
-    if (term.cursor_x >= term.cols) {
+    // Deferred wrap: if previous char set wrap_next, wrap now
+    if (term.wrap_next) {
         if (term.decawm) {
             term.cursor_x = 0;
             term.insertNewline();
-        } else {
-            term.cursor_x = term.cols - 1;
         }
+        term.wrap_next = false;
     }
 
-    // Wide char needs 2 columns — wrap if at last column
+    // Wide char needs 2 columns — wrap if only 1 column left
     if (wide and term.cursor_x + 1 >= term.cols) {
         if (term.decawm) {
             term.setCell(term.cursor_x, term.cursor_y, Cell{});
             term.cursor_x = 0;
             term.insertNewline();
+        }
+    }
+
+    // Insert mode: shift existing chars right before printing
+    if (term.insert_mode) {
+        const width: u32 = if (wide) 2 else 1;
+        if (term.cursor_x + width < term.cols) {
+            term.insertChars(width);
         }
     }
 
@@ -725,7 +747,7 @@ fn handlePrint(cp: u21, term: *Term) void {
     if (wide) attrs.wide = true;
 
     const cell = Cell{
-        .char = cp,
+        .char = actual_cp,
         .fg = term.current_fg,
         .bg = term.current_bg,
         .attrs = attrs,
@@ -740,29 +762,47 @@ fn handlePrint(cp: u21, term: *Term) void {
         term.setBgRgb(term.cursor_x, term.cursor_y, rgb) catch {};
     }
 
-    term.last_printed_char = cp;
-    term.cursor_x += 1;
+    term.last_printed_char = actual_cp;
 
-    // Wide char: set dummy cell for right half
-    if (wide and term.cursor_x < term.cols) {
-        var dummy = Cell{ .bg = term.current_bg };
-        dummy.attrs.wide_dummy = true;
-        term.setCell(term.cursor_x, term.cursor_y, dummy);
-        term.cursor_x += 1;
+    // Advance cursor or set deferred wrap
+    const width: u32 = if (wide) 2 else 1;
+    if (term.cursor_x + width < term.cols) {
+        term.cursor_x += width;
+        // Wide char: set dummy cell for right half
+        if (wide) {
+            var dummy = Cell{ .bg = term.current_bg };
+            dummy.attrs.wide_dummy = true;
+            term.setCell(term.cursor_x - 1, term.cursor_y, dummy);
+        }
+    } else {
+        // At right margin — set deferred wrap, don't advance
+        if (wide and term.cursor_x + 1 < term.cols) {
+            // Wide char placed, set dummy at cursor_x + 1
+            var dummy = Cell{ .bg = term.current_bg };
+            dummy.attrs.wide_dummy = true;
+            term.setCell(term.cursor_x + 1, term.cursor_y, dummy);
+        }
+        term.cursor_x = term.cols - 1;
+        term.wrap_next = true;
     }
 }
 
 fn handleControl(c: u8, term: *Term) void {
     switch (c) {
-        0x0A, 0x0B, 0x0C => term.insertNewline(), // LF, VT, FF
+        0x0A, 0x0B, 0x0C => { // LF, VT, FF
+            term.wrap_next = false;
+            if (term.linefeed_mode) term.cursor_x = 0;
+            term.insertNewline();
+        },
         0x0D => term.carriageReturn(), // CR
         0x08 => { // BS
+            term.wrap_next = false;
             if (term.cursor_x > 0) term.cursor_x -= 1;
         },
-        0x09 => { // HT — advance to next tab stop (every 8 columns)
-            term.cursor_x = @min(((term.cursor_x / 8) + 1) * 8, term.cols -| 1);
-        },
+        0x09 => term.tputtab(1), // HT — advance to next tab stop
         0x07 => {}, // BEL — ignore
+        0x0E => term.charset = 1, // SO (LS1 — Locking shift 1, activate G1)
+        0x0F => term.charset = 0, // SI (LS0 — Locking shift 0, activate G0)
         else => {},
     }
 }
@@ -774,23 +814,23 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
     switch (csi.final_byte) {
         'A' => { // CUU — cursor up (respects scroll region)
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
-            // Stop at scroll_top if cursor is within scroll region, else stop at row 0
+            term.wrap_next = false;
             const min_y: u32 = if (term.cursor_y >= term.scroll_top and term.cursor_y <= term.scroll_bottom)
                 term.scroll_top
             else
                 0;
             term.cursor_y = if (term.cursor_y >= n) @max(term.cursor_y - n, min_y) else min_y;
         },
-        'B' => { // CUD — cursor down (respects scroll region)
+        'B', 'e' => { // CUD/VPR — cursor down (respects scroll region)
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
-            // Stop at scroll_bottom if cursor is within scroll region, else stop at last row
+            term.wrap_next = false;
             const max_y: u32 = if (term.cursor_y >= term.scroll_top and term.cursor_y <= term.scroll_bottom)
                 term.scroll_bottom
             else
                 term.rows -| 1;
             term.cursor_y = @min(term.cursor_y + n, max_y);
         },
-        'C' => { // CUF — cursor forward
+        'C', 'a' => { // CUF/HPR — cursor forward
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
             term.moveCursorRel(@as(i32, @intCast(n)), 0);
         },
@@ -808,9 +848,10 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             term.moveCursorRel(0, -@as(i32, @intCast(n)));
             term.cursor_x = 0;
         },
-        'G' => { // CHA — cursor horizontal absolute (1-indexed)
+        'G', '`' => { // CHA/HPA — cursor horizontal absolute (1-indexed)
             const col = if (pc > 0 and p[0] > 0) p[0] - 1 else 0;
             term.cursor_x = @min(@as(u32, @intCast(col)), term.cols -| 1);
+            term.wrap_next = false;
         },
         'H', 'f' => { // CUP — cursor position (1-indexed params)
             const row = if (pc > 0 and p[0] > 0) p[0] - 1 else 0;
@@ -848,6 +889,7 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
         'd' => { // VPA — vertical position absolute (1-indexed)
             const row = if (pc > 0 and p[0] > 0) p[0] - 1 else 0;
             term.cursor_y = @min(@as(u32, @intCast(row)), term.rows -| 1);
+            term.wrap_next = false;
         },
         'm' => {
             // SGR only without private marker; \e[>4;2m is "Modify Other Keys", not SGR
@@ -862,11 +904,17 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             }
         },
         'n' => { // DSR — device status report
-            if (csi.private_marker == 0 and pc > 0 and p[0] == 6) {
+            if (csi.private_marker == 0 and pc > 0) {
                 if (writer_fd) |fd| {
-                    var buf: [32]u8 = undefined;
-                    const response = std.fmt.bufPrint(&buf, "\x1b[{d};{d}R", .{ term.cursor_y + 1, term.cursor_x + 1 }) catch return;
-                    _ = std.posix.write(fd, response) catch {};
+                    if (p[0] == 5) {
+                        // Status Report — respond "OK"
+                        _ = std.posix.write(fd, "\x1b[0n") catch {};
+                    } else if (p[0] == 6) {
+                        // Cursor Position Report
+                        var buf: [32]u8 = undefined;
+                        const response = std.fmt.bufPrint(&buf, "\x1b[{d};{d}R", .{ term.cursor_y + 1, term.cursor_x + 1 }) catch return;
+                        _ = std.posix.write(fd, response) catch {};
+                    }
                 }
             }
         },
@@ -893,9 +941,9 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             const top = if (pc > 0 and p[0] > 0) p[0] - 1 else 0;
             const bot = if (pc > 1 and p[1] > 0) p[1] - 1 else @as(u16, @intCast(term.rows -| 1));
             term.setScrollRegion(@intCast(top), @intCast(bot));
-            // VT spec: DECSTBM resets cursor to home position
             term.cursor_x = 0;
             term.cursor_y = 0;
+            term.wrap_next = false;
         },
         's' => { // Save cursor (only without private marker; \e[?s is XTPUSHCOLORS)
             if (csi.private_marker == 0) {
@@ -909,11 +957,42 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
                 term.cursor_y = term.saved_cursor_y;
             }
         },
-        'h' => { // DECSET
-            if (csi.private_marker == '?') handleDecSet(csi, term, true);
+        'g' => { // TBC — tab clear
+            if (pc == 0 or p[0] == 0) {
+                // Clear current tab stop
+                if (term.cursor_x < term.tabs.len) term.tabs[@intCast(term.cursor_x)] = false;
+            } else if (p[0] == 3) {
+                // Clear all tab stops
+                @memset(term.tabs, false);
+            }
         },
-        'l' => { // DECRST
-            if (csi.private_marker == '?') handleDecSet(csi, term, false);
+        'I' => { // CHT — cursor forward tabulation
+            const n = if (pc > 0 and p[0] > 0) p[0] else 1;
+            term.tputtab(@intCast(n));
+        },
+        'Z' => { // CBT — cursor backward tabulation
+            const n = if (pc > 0 and p[0] > 0) p[0] else 1;
+            term.tputtab(-@as(i32, @intCast(n)));
+        },
+        'h' => { // SM/DECSET — set mode
+            if (csi.private_marker == '?') {
+                handleDecSet(csi, term, true);
+            } else {
+                handleNonPrivateMode(csi, term, true);
+            }
+        },
+        'l' => { // RM/DECRST — reset mode
+            if (csi.private_marker == '?') {
+                handleDecSet(csi, term, false);
+            } else {
+                handleNonPrivateMode(csi, term, false);
+            }
+        },
+        'q' => {
+            // DECSCUSR — Set Cursor Style (CSI Ps SP q)
+            if (csi.intermediate_count > 0 and csi.intermediates[0] == ' ') {
+                term.cursor_style = if (pc > 0) @intCast(p[0]) else 0;
+            }
         },
         else => {
             std.log.warn("unhandled CSI: private={c} params={d}..{d} final={c}", .{
@@ -945,14 +1024,20 @@ fn handleSgr(csi: CsiAction, term: *Term) void {
             2 => term.current_attrs.dim = true,
             3 => term.current_attrs.italic = true,
             4 => term.current_attrs.underline = true,
+            5, 6 => term.current_attrs.blink = true, // slow/rapid blink
             7 => term.current_attrs.reverse = true,
+            8 => term.current_attrs.invisible = true,
+            9 => term.current_attrs.strikethrough = true,
             22 => {
                 term.current_attrs.bold = false;
                 term.current_attrs.dim = false;
             },
             23 => term.current_attrs.italic = false,
             24 => term.current_attrs.underline = false,
+            25 => term.current_attrs.blink = false,
             27 => term.current_attrs.reverse = false,
+            28 => term.current_attrs.invisible = false,
+            29 => term.current_attrs.strikethrough = false,
             30...37 => term.current_fg = @intCast(param - 30),
             38 => {
                 // Extended foreground
@@ -1038,6 +1123,12 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
     while (i < pc) : (i += 1) {
         switch (p[i]) {
             1 => term.decckm = set,
+            6 => { // DECOM — origin mode
+                term.origin_mode = set;
+                term.cursor_x = 0;
+                term.cursor_y = if (set) term.scroll_top else 0;
+                term.wrap_next = false;
+            },
             7 => term.decawm = set,
             25 => term.cursor_visible = set,
             47, 1047 => {
@@ -1045,18 +1136,29 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     std.log.err("switchScreen failed: {}", .{err});
                 };
             },
+            1048 => { // Save/restore cursor independently
+                if (set) {
+                    term.saved_cursor_x = term.cursor_x;
+                    term.saved_cursor_y = term.cursor_y;
+                } else {
+                    term.cursor_x = term.saved_cursor_x;
+                    term.cursor_y = term.saved_cursor_y;
+                    term.wrap_next = false;
+                }
+            },
             1049 => {
                 if (set) {
                     term.saved_cursor_x = term.cursor_x;
                     term.saved_cursor_y = term.cursor_y;
                     term.saved_scroll_top = term.scroll_top;
                     term.saved_scroll_bottom = term.scroll_bottom;
+                    term.saved_wrap_next = term.wrap_next;
                     term.switchScreen(true) catch |err| {
                         std.log.err("switchScreen failed: {}", .{err});
                     };
-                    // Reset scroll region for alt screen (full screen)
                     term.scroll_top = 0;
                     term.scroll_bottom = term.rows -| 1;
+                    term.wrap_next = false;
                     term.eraseDisplay(2);
                 } else {
                     term.switchScreen(false) catch |err| {
@@ -1066,10 +1168,13 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     term.cursor_y = term.saved_cursor_y;
                     term.scroll_top = term.saved_scroll_top;
                     term.scroll_bottom = term.saved_scroll_bottom;
+                    term.wrap_next = term.saved_wrap_next;
                 }
             },
             2004 => term.bracketed_paste = set,
             2026 => term.sync_update = set,
+            // Silently ignored modes (common, no-op for us)
+            0, 2, 3, 4, 5, 8, 12, 18, 19, 42 => {},
             else => {
                 std.log.warn("unhandled DEC mode: {d} set={}", .{ p[i], set });
             },
@@ -1077,28 +1182,79 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
     }
 }
 
-fn handleEsc(esc: EscAction, term: *Term) void {
+fn handleEsc(esc: EscAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
+    // Character set designation (ESC with intermediate byte)
+    if (esc.intermediate != 0) {
+        switch (esc.intermediate) {
+            '(' => term.charsets[0] = charsetFromByte(esc.final_byte), // G0
+            ')' => term.charsets[1] = charsetFromByte(esc.final_byte), // G1
+            '*' => term.charsets[2] = charsetFromByte(esc.final_byte), // G2
+            '+' => term.charsets[3] = charsetFromByte(esc.final_byte), // G3
+            '#' => {
+                if (esc.final_byte == '8') {
+                    // DECALN — fill screen with 'E'
+                    for (0..term.rows) |y| {
+                        for (0..term.cols) |x| {
+                            term.setCell(@intCast(x), @intCast(y), .{ .char = 'E', .fg = 7 });
+                        }
+                    }
+                }
+            },
+            else => {},
+        }
+        return;
+    }
+
     switch (esc.final_byte) {
-        '7' => { // DECSC — save cursor
+        '7' => { // DECSC — save cursor (with attributes, like st)
             term.saved_cursor_x = term.cursor_x;
             term.saved_cursor_y = term.cursor_y;
+            term.saved_attrs = term.current_attrs;
+            term.saved_fg = term.current_fg;
+            term.saved_bg = term.current_bg;
+            term.saved_charset = term.charset;
+            term.saved_wrap_next = term.wrap_next;
+            term.saved_origin_mode = term.origin_mode;
         },
-        '8' => { // DECRC — restore cursor
+        '8' => { // DECRC — restore cursor (with attributes)
             term.cursor_x = term.saved_cursor_x;
             term.cursor_y = term.saved_cursor_y;
+            term.current_attrs = term.saved_attrs;
+            term.current_fg = term.saved_fg;
+            term.current_bg = term.saved_bg;
+            term.charset = term.saved_charset;
+            term.wrap_next = term.saved_wrap_next;
+            term.origin_mode = term.saved_origin_mode;
         },
-        'D' => { // IND — index (cursor down, scroll if at bottom of scroll region)
+        'D' => { // IND — index (cursor down, scroll if at bottom)
+            term.wrap_next = false;
             if (term.cursor_y == term.scroll_bottom) {
                 term.scrollUp(1);
             } else if (term.cursor_y < term.rows - 1) {
                 term.cursor_y += 1;
             }
         },
+        'E' => { // NEL — next line (always go to first col)
+            term.wrap_next = false;
+            term.cursor_x = 0;
+            term.insertNewline();
+        },
+        'H' => { // HTS — horizontal tab stop (set tab at current column)
+            if (term.cursor_x < term.tabs.len) {
+                term.tabs[@intCast(term.cursor_x)] = true;
+            }
+        },
         'M' => { // RI — reverse index
+            term.wrap_next = false;
             if (term.cursor_y == term.scroll_top) {
                 term.scrollDown(1);
             } else if (term.cursor_y > 0) {
                 term.cursor_y -= 1;
+            }
+        },
+        'Z' => { // DECID — identify terminal
+            if (writer_fd) |fd| {
+                _ = std.posix.write(fd, "\x1b[?62;22c") catch {};
             }
         },
         'c' => { // RIS — full reset
@@ -1117,14 +1273,48 @@ fn handleEsc(esc: EscAction, term: *Term) void {
             term.decawm = true;
             term.cursor_visible = true;
             term.bracketed_paste = false;
+            term.wrap_next = false;
+            term.insert_mode = false;
+            term.linefeed_mode = false;
+            term.charset = 0;
+            term.charsets = .{ .us_ascii, .us_ascii, .us_ascii, .us_ascii };
+            term.deckpam = false;
+            term.origin_mode = false;
+            term.cursor_style = 0;
+            // Reset tab stops to default (every 8 columns)
+            for (0..term.tabs.len) |c| {
+                term.tabs[c] = (c % 8 == 0) and c > 0;
+            }
             term.eraseDisplay(2);
         },
+        '=' => term.deckpam = true, // DECPAM — application keypad
+        '>' => term.deckpam = false, // DECPNM — normal keypad
         else => {
             std.log.warn("unhandled ESC: intermediate={c} final={c}", .{
                 if (esc.intermediate != 0) esc.intermediate else @as(u8, '-'),
                 esc.final_byte,
             });
         },
+    }
+}
+
+fn charsetFromByte(b: u8) term_mod.CharsetType {
+    return switch (b) {
+        '0' => .dec_graphics,
+        else => .us_ascii, // 'B' (US ASCII) and all others default to ASCII
+    };
+}
+
+fn handleNonPrivateMode(csi: CsiAction, term: *Term, set: bool) void {
+    const p = csi.params;
+    const pc = csi.param_count;
+    var idx: u8 = 0;
+    while (idx < pc) : (idx += 1) {
+        switch (p[idx]) {
+            4 => term.insert_mode = set, // IRM — Insert/Replace Mode
+            20 => term.linefeed_mode = set, // LNM — Linefeed/Newline Mode
+            else => {},
+        }
     }
 }
 

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -224,7 +224,8 @@ pub const Parser = struct {
     }
 
     fn handleCsiEntry(self: *Parser, byte: u8) Action {
-        if (byte == '?' or byte == '>') {
+        if (byte >= 0x3C and byte <= 0x3F) {
+            // Private marker bytes: < = > ?
             self.private_marker = byte;
             self.state = .csi_param;
             return .none;
@@ -895,11 +896,14 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             // SGR only without private marker; \e[>4;2m is "Modify Other Keys", not SGR
             if (csi.private_marker == 0) handleSgr(csi, term);
         },
-        'c' => { // DA1 — device attributes
-            if (csi.private_marker == 0) {
-                if (writer_fd) |fd| {
-                    // Report as VT220 with basic capabilities
+        'c' => { // Device Attributes
+            if (writer_fd) |fd| {
+                if (csi.private_marker == 0) {
+                    // DA1 — report as VT220
                     _ = std.posix.write(fd, "\x1b[?62;22c") catch {};
+                } else if (csi.private_marker == '>') {
+                    // DA2 — secondary device attributes (xterm-compatible)
+                    _ = std.posix.write(fd, "\x1b[>0;0;0c") catch {};
                 }
             }
         },
@@ -977,30 +981,67 @@ fn handleCsi(csi: CsiAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
         'h' => { // SM/DECSET — set mode
             if (csi.private_marker == '?') {
                 handleDecSet(csi, term, true);
-            } else {
+            } else if (csi.private_marker == 0) {
                 handleNonPrivateMode(csi, term, true);
             }
+            // CSI > h, CSI < h — silently ignore (xterm/kitty private)
         },
         'l' => { // RM/DECRST — reset mode
             if (csi.private_marker == '?') {
                 handleDecSet(csi, term, false);
-            } else {
+            } else if (csi.private_marker == 0) {
                 handleNonPrivateMode(csi, term, false);
             }
+            // CSI > l, CSI < l — silently ignore
+        },
+        'p' => {
+            // DECSTR — Soft Terminal Reset (CSI ! p)
+            if (csi.intermediate_count > 0 and csi.intermediates[0] == '!') {
+                // Reset terminal state (like RIS but keep screen content)
+                term.cursor_x = 0;
+                term.cursor_y = 0;
+                term.wrap_next = false;
+                term.insert_mode = false;
+                term.linefeed_mode = false;
+                term.origin_mode = false;
+                term.decawm = true;
+                term.decckm = false;
+                term.cursor_visible = true;
+                term.current_fg = 7;
+                term.current_bg = 0;
+                term.current_attrs = .{};
+                term.current_fg_rgb = null;
+                term.current_bg_rgb = null;
+                term.charset = 0;
+                term.charsets = .{ .us_ascii, .us_ascii, .us_ascii, .us_ascii };
+                term.scroll_top = 0;
+                term.scroll_bottom = term.rows -| 1;
+                for (0..term.tabs.len) |c_idx| {
+                    term.tabs[c_idx] = (c_idx % 8 == 0) and c_idx > 0;
+                }
+            }
+            // CSI > p, CSI ? p — silently ignore (XTPUSHCOLORS, DECRPM)
         },
         'q' => {
-            // DECSCUSR — Set Cursor Style (CSI Ps SP q)
             if (csi.intermediate_count > 0 and csi.intermediates[0] == ' ') {
+                // DECSCUSR — Set Cursor Style
                 term.cursor_style = if (pc > 0) @intCast(p[0]) else 0;
             }
+            // CSI > q (XTVERSION) — silently ignore for now
+        },
+        't' => {
+            // Window operations (XTWINOPS) — silently accept
+            // CSI 22;0;0 t (save title), CSI 23;0;0 t (restore title), etc.
         },
         else => {
-            std.log.warn("unhandled CSI: private={c} params={d}..{d} final={c}", .{
-                if (csi.private_marker != 0) csi.private_marker else @as(u8, '-'),
-                if (pc > 0) p[0] else 0,
-                if (pc > 1) p[1] else 0,
-                csi.final_byte,
-            });
+            // Only warn for sequences without private markers (reduce noise)
+            if (csi.private_marker == 0 and csi.intermediate_count == 0) {
+                std.log.warn("unhandled CSI: params={d}..{d} final={c}", .{
+                    if (pc > 0) p[0] else 0,
+                    if (pc > 1) p[1] else 0,
+                    csi.final_byte,
+                });
+            }
         },
     }
 }
@@ -1173,7 +1214,17 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
             },
             2004 => term.bracketed_paste = set,
             2026 => term.sync_update = set,
-            // Silently ignored modes (common, no-op for us)
+            // Mouse tracking modes (accepted but not processed — no mouse support yet)
+            9, 1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016 => {},
+            // Focus events (accepted, not implemented)
+            1004 => {},
+            // Alt scroll mode
+            1007 => {},
+            // Meta key mode
+            1034 => {},
+            // Left/right margin mode
+            69 => {},
+            // Silently ignored DEC modes
             0, 2, 3, 4, 5, 8, 12, 18, 19, 42 => {},
             else => {
                 std.log.warn("unhandled DEC mode: {d} set={}", .{ p[i], set });


### PR DESCRIPTION
## Summary
- **Deferred wrap (CURSOR_WRAPNEXT)**: Fix character remnant artifacts in TUI apps (Claude Code etc.) by deferring line wrap until next printable char, matching st/xterm behavior
- **VT100 character sets**: DEC Graphics line drawing (ESC(0), SO/SI locking shifts for box-drawing characters
- **Settable tab stops**: HTS, TBC, CHT, CBT replacing hardcoded 8-column tabs
- **Insert mode (IRM)**, LNM, DECOM, DECPAM/DECPNM, DECSCUSR, and 15+ other missing CSI/ESC/SGR sequences
- **Cell.Attrs u8→u16**: Added blink, invisible, strikethrough without increasing Cell size (stays 8 bytes)

## Test plan
- [x] `zig build` passes
- [x] `zig build test` passes
- [ ] Manual test: run Claude Code in zt, verify no character remnants
- [ ] Manual test: verify ncurses box drawing (mc, htop) renders correctly
- [ ] Manual test: vttest basic functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テキスト属性に点滅・非表示・取消線を追加
  * DEC特殊グラフィックスを含む文字セット選択 (SO/SI切替対応)
  * カーソル保存/復元で属性・文字セット・折返し・起点モードを保持
  * タブ移動コマンドと動的タブ管理、挿入モードの挙動強化
  * 追加のCSI/ESCシーケンス（カーソルスタイル、タブ制御、ソフトリセット等）

* **バグ修正**
  * 右端折返しの遅延処理で整合性改善
  * 消去/クリア処理を背景色考慮(BCE)で安定化
  * 各種制御応答やモード切替の動作改善

* **ドキュメント**
  * サポートシーケンス表とテスト済アプリ情報を拡充

* **雑務**
  * パッケージバージョン更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->