### PR TITLE
Fix macOS backend: compilation, window display, and keyboard input

### DIFF
--- a/src/backend/macos.zig
+++ b/src/backend/macos.zig
@@ -122,6 +122,12 @@ fn msgSend_void_id(target: id, _sel: SEL, arg: id) void {
     f(target, _sel, arg);
 }
 
+// id, ?id → void (for methods that accept nil, e.g. makeKeyAndOrderFront:)
+fn msgSend_void_optid(target: id, _sel: SEL, arg: ?id) void {
+    const f: *const fn (id, SEL, ?id) callconv(.c) void = @ptrCast(&objc_msgSend);
+    f(target, _sel, arg);
+}
+
 // id, id → id
 fn msgSend_id_id(target: id, _sel: SEL, arg: id) id {
     const f: *const fn (id, SEL, id) callconv(.c) id = @ptrCast(&objc_msgSend);
@@ -378,7 +384,7 @@ pub const MacosBackend = struct {
         msgSend_void_id(window, sel("setTitle:"), title_str);
 
         // 10. Show window
-        msgSend_void_id(window, sel("makeKeyAndOrderFront:"), @as(id, @ptrFromInt(0)));
+        msgSend_void_optid(window, sel("makeKeyAndOrderFront:"), null);
         msgSend_void_bool(app, sel("activateIgnoringOtherApps:"), YES);
 
         // NOTE: The backend pointer ivar is set in postInit() after the struct
@@ -581,35 +587,35 @@ fn registerZTViewClass() ?id {
     }
 
     // --- NSView overrides ---
-    _ = class_addMethod(new_class, sel("drawRect:"), @ptrCast(&ztDrawRect), "v@:{CGRect=dddd}");
-    _ = class_addMethod(new_class, sel("acceptsFirstResponder"), @ptrCast(&ztAcceptsFirstResponder), "c@:");
-    _ = class_addMethod(new_class, sel("canBecomeKeyView"), @ptrCast(&ztCanBecomeKeyView), "c@:");
+    _ = class_addMethod(new_class, sel("drawRect:"), @constCast(@ptrCast(&ztDrawRect)), "v@:{CGRect=dddd}");
+    _ = class_addMethod(new_class, sel("acceptsFirstResponder"), @constCast(@ptrCast(&ztAcceptsFirstResponder)), "c@:");
+    _ = class_addMethod(new_class, sel("canBecomeKeyView"), @constCast(@ptrCast(&ztCanBecomeKeyView)), "c@:");
 
     // --- Keyboard ---
-    _ = class_addMethod(new_class, sel("keyDown:"), @ptrCast(&ztKeyDown), "v@:@");
-    _ = class_addMethod(new_class, sel("flagsChanged:"), @ptrCast(&ztFlagsChanged), "v@:@");
+    _ = class_addMethod(new_class, sel("keyDown:"), @constCast(@ptrCast(&ztKeyDown)), "v@:@");
+    _ = class_addMethod(new_class, sel("flagsChanged:"), @constCast(@ptrCast(&ztFlagsChanged)), "v@:@");
 
     // --- NSTextInputClient ---
-    _ = class_addMethod(new_class, sel("insertText:replacementRange:"), @ptrCast(&ztInsertText), "v@:@{_NSRange=QQ}");
-    _ = class_addMethod(new_class, sel("hasMarkedText"), @ptrCast(&ztHasMarkedText), "c@:");
-    _ = class_addMethod(new_class, sel("setMarkedText:selectedRange:replacementRange:"), @ptrCast(&ztSetMarkedText), "v@:@{_NSRange=QQ}{_NSRange=QQ}");
-    _ = class_addMethod(new_class, sel("unmarkText"), @ptrCast(&ztUnmarkText), "v@:");
-    _ = class_addMethod(new_class, sel("validAttributesForMarkedText"), @ptrCast(&ztValidAttributes), "@@:");
-    _ = class_addMethod(new_class, sel("firstRectForCharacterRange:actualRange:"), @ptrCast(&ztFirstRect), "{CGRect=dddd}@:{_NSRange=QQ}^{_NSRange=QQ}");
-    _ = class_addMethod(new_class, sel("characterIndexForPoint:"), @ptrCast(&ztCharacterIndex), "Q@:{CGPoint=dd}");
-    _ = class_addMethod(new_class, sel("attributedSubstringForProposedRange:actualRange:"), @ptrCast(&ztAttributedSubstring), "@@:{_NSRange=QQ}^{_NSRange=QQ}");
-    _ = class_addMethod(new_class, sel("markedRange"), @ptrCast(&ztMarkedRange), "{_NSRange=QQ}@:");
-    _ = class_addMethod(new_class, sel("selectedRange"), @ptrCast(&ztSelectedRange), "{_NSRange=QQ}@:");
+    _ = class_addMethod(new_class, sel("insertText:replacementRange:"), @constCast(@ptrCast(&ztInsertText)), "v@:@{_NSRange=QQ}");
+    _ = class_addMethod(new_class, sel("hasMarkedText"), @constCast(@ptrCast(&ztHasMarkedText)), "c@:");
+    _ = class_addMethod(new_class, sel("setMarkedText:selectedRange:replacementRange:"), @constCast(@ptrCast(&ztSetMarkedText)), "v@:@{_NSRange=QQ}{_NSRange=QQ}");
+    _ = class_addMethod(new_class, sel("unmarkText"), @constCast(@ptrCast(&ztUnmarkText)), "v@:");
+    _ = class_addMethod(new_class, sel("validAttributesForMarkedText"), @constCast(@ptrCast(&ztValidAttributes)), "@@:");
+    _ = class_addMethod(new_class, sel("firstRectForCharacterRange:actualRange:"), @constCast(@ptrCast(&ztFirstRect)), "{CGRect=dddd}@:{_NSRange=QQ}^{_NSRange=QQ}");
+    _ = class_addMethod(new_class, sel("characterIndexForPoint:"), @constCast(@ptrCast(&ztCharacterIndex)), "Q@:{CGPoint=dd}");
+    _ = class_addMethod(new_class, sel("attributedSubstringForProposedRange:actualRange:"), @constCast(@ptrCast(&ztAttributedSubstring)), "@@:{_NSRange=QQ}^{_NSRange=QQ}");
+    _ = class_addMethod(new_class, sel("markedRange"), @constCast(@ptrCast(&ztMarkedRange)), "{_NSRange=QQ}@:");
+    _ = class_addMethod(new_class, sel("selectedRange"), @constCast(@ptrCast(&ztSelectedRange)), "{_NSRange=QQ}@:");
 
     // --- NSWindowDelegate ---
-    _ = class_addMethod(new_class, sel("windowShouldClose:"), @ptrCast(&ztWindowShouldClose), "c@:@");
-    _ = class_addMethod(new_class, sel("windowDidBecomeKey:"), @ptrCast(&ztWindowDidBecomeKey), "v@:@");
-    _ = class_addMethod(new_class, sel("windowDidResignKey:"), @ptrCast(&ztWindowDidResignKey), "v@:@");
-    _ = class_addMethod(new_class, sel("windowDidResize:"), @ptrCast(&ztWindowDidResize), "v@:@");
-    _ = class_addMethod(new_class, sel("windowDidChangeOcclusionState:"), @ptrCast(&ztWindowDidChangeOcclusion), "v@:@");
+    _ = class_addMethod(new_class, sel("windowShouldClose:"), @constCast(@ptrCast(&ztWindowShouldClose)), "c@:@");
+    _ = class_addMethod(new_class, sel("windowDidBecomeKey:"), @constCast(@ptrCast(&ztWindowDidBecomeKey)), "v@:@");
+    _ = class_addMethod(new_class, sel("windowDidResignKey:"), @constCast(@ptrCast(&ztWindowDidResignKey)), "v@:@");
+    _ = class_addMethod(new_class, sel("windowDidResize:"), @constCast(@ptrCast(&ztWindowDidResize)), "v@:@");
+    _ = class_addMethod(new_class, sel("windowDidChangeOcclusionState:"), @constCast(@ptrCast(&ztWindowDidChangeOcclusion)), "v@:@");
 
     // --- NSView backing properties ---
-    _ = class_addMethod(new_class, sel("viewDidChangeBackingProperties"), @ptrCast(&ztViewDidChangeBackingProperties), "v@:");
+    _ = class_addMethod(new_class, sel("viewDidChangeBackingProperties"), @constCast(@ptrCast(&ztViewDidChangeBackingProperties)), "v@:");
 
     objc_registerClassPair(new_class);
     zt_view_class_registered = new_class;

--- a/src/backend/macos.zig
+++ b/src/backend/macos.zig
@@ -597,6 +597,11 @@ fn registerZTViewClass() ?id {
     // --- Keyboard ---
     _ = class_addMethod(new_class, sel("keyDown:"), @constCast(@ptrCast(&ztKeyDown)), "v@:@");
     _ = class_addMethod(new_class, sel("flagsChanged:"), @constCast(@ptrCast(&ztFlagsChanged)), "v@:@");
+    // doCommandBySelector: is called by interpretKeyEvents: for non-text
+    // keys (Enter, Tab, arrows, Escape, etc.). Without this, the default
+    // NSView implementation calls NSBeep() for every unhandled command.
+    // We handle all keys through the evdev key event path, so this is a no-op.
+    _ = class_addMethod(new_class, sel("doCommandBySelector:"), @constCast(@ptrCast(&ztDoCommandBySelector)), "v@::");
 
     // --- NSTextInputClient ---
     _ = class_addMethod(new_class, sel("insertText:replacementRange:"), @constCast(@ptrCast(&ztInsertText)), "v@:@{_NSRange=QQ}");
@@ -653,6 +658,12 @@ fn ztAcceptsFirstResponder(_: id, _: SEL) callconv(.c) BOOL {
 
 fn ztCanBecomeKeyView(_: id, _: SEL) callconv(.c) BOOL {
     return YES;
+}
+
+fn ztDoCommandBySelector(_: id, _: SEL, _: SEL) callconv(.c) void {
+    // No-op: all keys are handled through the evdev key event path.
+    // Without this, NSView's default calls NSBeep() for every
+    // unhandled command selector (insertNewline:, insertTab:, etc.).
 }
 
 fn ztKeyDown(self_view: id, _: SEL, ns_event: id) callconv(.c) void {
@@ -742,9 +753,12 @@ fn ztInsertText(self_view: id, _: SEL, text_obj: id, _: NSRange) callconv(.c) vo
     const len = std.mem.len(cstr);
     if (len == 0) return;
 
-    // If single ASCII character that would be handled by keyDown, skip
-    // to avoid duplicates (interpretKeyEvents already pushed a key event).
-    if (len == 1 and cstr[0] >= 0x20 and cstr[0] < 0x7F) return;
+    // Skip all single-byte ASCII — these are already handled by the key
+    // event path (macosToEvdev → translateKey). Without this guard, keys
+    // like Enter (0x0D) and Tab (0x09) produce duplicates: one from the
+    // key event and one from insertText. Only let through multi-byte
+    // sequences (IME-composed text, dead key output, etc.).
+    if (len == 1 and cstr[0] < 0x80) return;
 
     var text_event: TextEvent = .{};
     const copy_len = @min(len, text_event.data.len);

--- a/src/backend/macos.zig
+++ b/src/backend/macos.zig
@@ -383,8 +383,11 @@ pub const MacosBackend = struct {
         const title_str = createNSString("zt");
         msgSend_void_id(window, sel("setTitle:"), title_str);
 
-        // 10. Show window
+        // 10. Show window and activate app
         msgSend_void_optid(window, sel("makeKeyAndOrderFront:"), null);
+        // finishLaunching is required for non-bundle apps to properly
+        // initialize the window server connection and menu bar.
+        msgSend_void(app, sel("finishLaunching"));
         msgSend_void_bool(app, sel("activateIgnoringOtherApps:"), YES);
 
         // NOTE: The backend pointer ivar is set in postInit() after the struct

--- a/src/main.zig
+++ b/src/main.zig
@@ -643,11 +643,15 @@ pub fn main() !void {
             }
         } else {
             // ---- macOS kqueue dispatch ----
+            // On macOS, we must pump the Cocoa run loop regularly for window
+            // display and event delivery. Never block indefinitely — cap at
+            // 16ms (~60hz) so the UI stays responsive even when idle.
+            const macos_timeout: i32 = if (event_timeout < 0) 16 else @min(event_timeout, 16);
             var timeout_buf: std.posix.timespec = .{
-                .sec = @divFloor(@as(isize, event_timeout), 1000),
-                .nsec = @rem(@as(isize, event_timeout), 1000) * 1_000_000,
+                .sec = @divFloor(@as(isize, macos_timeout), 1000),
+                .nsec = @rem(@as(isize, macos_timeout), 1000) * 1_000_000,
             };
-            const timeout_spec: ?*const std.posix.timespec = if (event_timeout < 0) null else &timeout_buf;
+            const timeout_spec: ?*const std.posix.timespec = &timeout_buf;
             var kevents: [16]std.posix.Kevent = undefined;
             const n = std.posix.kevent(evloop_fd, &.{}, &kevents, timeout_spec) catch 0;
 
@@ -758,6 +762,85 @@ pub fn main() !void {
                 } else if (kev.filter == std.c.EVFILT.TIMER) {
                     cursor_visible_blink = !cursor_visible_blink;
                     term.markDirty(term.cursor_x, term.cursor_y);
+                }
+            }
+
+            // Always pump Cocoa events, even if kqueue returned nothing.
+            // The Cocoa run loop must be serviced for window display, input
+            // delivery, and system event handling. Without this, the window
+            // never appears because Cocoa callbacks never fire.
+            if (config.backend == .macos) {
+                while (backend.pollEvents()) |event| {
+                    switch (event) {
+                        .key => |key_ev| {
+                            if (key_ev.pressed) {
+                                const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm);
+                                if (bytes.len > 0) {
+                                    if (!ptyBufferedWrite(&pty, bytes, &write_buf, &write_pending, evloop_fd)) {
+                                        running = false;
+                                        break;
+                                    }
+                                }
+                            }
+                        },
+                        .text => |text_ev| {
+                            const text = text_ev.slice();
+                            if (text.len > 0) {
+                                if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
+                                }
+                            }
+                        },
+                        .paste => |paste_ev| {
+                            const text = paste_ev.slice();
+                            if (text.len > 0) {
+                                if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
+                                }
+                            }
+                        },
+                        .resize => |rsz| {
+                            const new_cols = rsz.width / config.cell_width;
+                            const new_rows = rsz.height / config.cell_height;
+                            if (new_cols > 0 and new_rows > 0) {
+                                term.resize(new_cols, new_rows) catch |err| {
+                                    std.log.err("term resize: {}", .{err});
+                                };
+                                pty.resize(@intCast(new_cols), @intCast(new_rows)) catch |err| {
+                                    std.log.err("pty resize: {}", .{err});
+                                };
+                                backend.resize(rsz.width, rsz.height) catch |err| {
+                                    std.log.err("backend resize: {}", .{err});
+                                };
+                            }
+                        },
+                        .expose => {
+                            const total = @as(usize, term.cols) * @as(usize, term.rows);
+                            term.markDirtyRange(.{ .start = 0, .end = total });
+                            term.all_dirty = true;
+                        },
+                        .focus_in => {
+                            if (term.focus_events) {
+                                if (!ptyBufferedWrite(&pty, "\x1b[I", &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
+                                }
+                            }
+                        },
+                        .focus_out => {
+                            if (term.focus_events) {
+                                if (!ptyBufferedWrite(&pty, "\x1b[O", &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
+                                }
+                            }
+                        },
+                        .close => {
+                            running = false;
+                        },
+                    }
                 }
             }
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -179,10 +179,11 @@ fn kqueueAddTimer(kq: i32, ident: usize, interval_ms: isize) !void {
 }
 
 fn kqueueSetPtyWrite(kq: i32, pty_fd: std.posix.fd_t, enable: bool) void {
+    const flags: u16 = std.c.EV.ADD | if (enable) @as(u16, std.c.EV.ENABLE) else @as(u16, std.c.EV.DISABLE);
     const changelist = [1]std.posix.Kevent{.{
         .ident = @intCast(pty_fd),
         .filter = std.c.EVFILT.WRITE,
-        .flags = std.c.EV.ADD | if (enable) std.c.EV.ENABLE else std.c.EV.DISABLE,
+        .flags = flags,
         .fflags = 0,
         .data = 0,
         .udata = @intFromEnum(KqueueTag.pty),
@@ -285,7 +286,8 @@ const SIG_USR1 = if (is_linux) linux.SIG.USR1 else std.c.SIG.USR1;
 const SIG_USR2 = if (is_linux) linux.SIG.USR2 else std.c.SIG.USR2;
 
 fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend) bool {
-    const signo: u32 = if (signo_override) |s| s else blk: {
+    const signo: u32 = signo_override orelse blk: {
+        if (!is_linux) return true; // macOS always provides signo_override via kqueue
         var siginfo: linux.signalfd_siginfo = undefined;
         _ = std.posix.read(sig_fd, std.mem.asBytes(&siginfo)) catch return true;
         break :blk siginfo.signo;
@@ -641,10 +643,11 @@ pub fn main() !void {
             }
         } else {
             // ---- macOS kqueue dispatch ----
-            const timeout_spec: ?std.posix.timespec = if (event_timeout < 0) null else .{
+            var timeout_buf: std.posix.timespec = .{
                 .sec = @divFloor(@as(isize, event_timeout), 1000),
                 .nsec = @rem(@as(isize, event_timeout), 1000) * 1_000_000,
             };
+            const timeout_spec: ?*const std.posix.timespec = if (event_timeout < 0) null else &timeout_buf;
             var kevents: [16]std.posix.Kevent = undefined;
             const n = std.posix.kevent(evloop_fd, &.{}, &kevents, timeout_spec) catch 0;
 

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -115,7 +115,7 @@ pub const Pty = struct {
 
             // c. Set controlling terminal
             if (is_macos) {
-                _ = std.c.ioctl(@intCast(slave_fd), TIOCSCTTY, @as(c_int, 0));
+                _ = std.c.ioctl(@intCast(slave_fd), @bitCast(TIOCSCTTY), @as(c_int, 0));
             } else {
                 _ = linux.ioctl(@intCast(slave_fd), TIOCSCTTY, 0);
             }
@@ -123,7 +123,7 @@ pub const Pty = struct {
             // f. Set window size before dup2
             var ws = Winsize{ .ws_row = rows, .ws_col = cols };
             if (is_macos) {
-                _ = std.c.ioctl(@intCast(slave_fd), TIOCSWINSZ, @intFromPtr(&ws));
+                _ = std.c.ioctl(@intCast(slave_fd), @bitCast(TIOCSWINSZ), @intFromPtr(&ws));
             } else {
                 _ = linux.ioctl(@intCast(slave_fd), TIOCSWINSZ, @intFromPtr(&ws));
             }
@@ -245,9 +245,11 @@ pub const Pty = struct {
         // === Parent process ===
         // Set master_fd nonblocking
         if (is_macos) {
-            // macOS: use libc constants
-            const cur_flags = try posix.fcntl(master_fd, std.c.F.GETFL, 0);
-            _ = try posix.fcntl(master_fd, std.c.F.SETFL, cur_flags | std.c.O.NONBLOCK);
+            const F_GETFL = 3;
+            const F_SETFL = 4;
+            const O_NONBLOCK: u32 = 0x0004; // macOS O_NONBLOCK
+            const cur_flags = try posix.fcntl(master_fd, F_GETFL, 0);
+            _ = try posix.fcntl(master_fd, F_SETFL, cur_flags | O_NONBLOCK);
         } else {
             // Linux: named constants (not in std.os.linux.F)
             const F_GETFL = 3;
@@ -281,7 +283,7 @@ pub const Pty = struct {
     pub fn resize(self: *Pty, cols: u16, rows: u16) !void {
         var ws = Winsize{ .ws_row = rows, .ws_col = cols };
         if (is_macos) {
-            const rc = std.c.ioctl(@intCast(self.master_fd), TIOCSWINSZ, @intFromPtr(&ws));
+            const rc = std.c.ioctl(@intCast(self.master_fd), @bitCast(TIOCSWINSZ), @intFromPtr(&ws));
             if (rc < 0) return error.IoctlFailed;
         } else {
             const rc = linux.ioctl(


### PR DESCRIPTION
## Summary

Tested the macOS backend on real hardware (Apple Silicon, macOS) and fixed the issues preventing it from working:

- **Compilation fixes for Zig 0.15**: null pointer cast (`@ptrFromInt(0)` for non-optional `id`), `@constCast` needed on 21 `class_addMethod` function pointer casts, `TIOCSWINSZ` u32 overflow for `c_int` in ioctl, `std.c.O.NONBLOCK` packed struct vs integer mismatch, kevent timeout pointer-vs-value type, comptime_int in runtime conditional for EV flags, and `linux.signalfd_siginfo` referenced on macOS
- **Window not appearing**: the kqueue event loop blocked indefinitely waiting for the Cocoa wakeup pipe, but the pipe only gets written by Cocoa callbacks that require the run loop to be pumped first — a deadlock. Fixed by capping kqueue timeout at 16ms on macOS and pumping `pollEvents()` unconditionally every iteration. Also added `[NSApp finishLaunching]` which is required for non-bundle apps.
- **NSBeep on every keypress**: `interpretKeyEvents:` dispatches command selectors (e.g. `insertNewline:` for Enter) to the view, and without `doCommandBySelector:` the default NSView implementation calls `NSBeep()`. Added it as a no-op since all keys are handled through the evdev path. Also tightened the `insertText:` ASCII filter to skip all single-byte chars (< 0x80) to prevent duplicate input.

Tested on macOS with Apple Silicon — window appears, shell is interactive, typing works, resize works.

## Test plan
- [x] `zig build -Dbackend=macos -Doptimize=Debug` compiles clean
- [x] `zig build -Dbackend=macos -Doptimize=ReleaseFast` compiles clean
- [x] `zig build test` (default backend) still passes
- [x] Window appears on launch
- [x] Shell is interactive (typing, Enter, Tab, arrows)
- [x] No spurious beeps
- [x] Cmd+Q closes the window
- [x] Window resize works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **バグ修正**
  * macOS での Cocoa イベント処理を改善し、アプリケーションの応答性を向上
  * macOS での PTY（疑似端末）操作の安定性を強化
  * メインループのタイムアウト動作を改善し、無限ブロックの問題を解決

* **パフォーマンス改善**
  * macOS でのイベントポーリングループに上限を設定し、システムリソースの効率化を実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->