### PR TITLE
macOS: address review feedback from PR #2

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -307,6 +307,85 @@ fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend)
     };
 }
 
+/// Handle a single backend event (key, text, paste, resize, etc.).
+/// Returns false if the event loop should stop (close event or write failure).
+fn handleBackendEvent(
+    event: BackendEvent,
+    term: *@import("term.zig").Term,
+    pty_ptr: *Pty,
+    backend: *Backend,
+    write_buf: *[4096]u8,
+    write_pending: *usize,
+    evloop_fd: i32,
+) bool {
+    switch (event) {
+        .key => |key_ev| {
+            if (key_ev.pressed) {
+                const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm);
+                if (bytes.len > 0) {
+                    if (!ptyBufferedWrite(pty_ptr, bytes, write_buf, write_pending, evloop_fd)) {
+                        return false;
+                    }
+                }
+            }
+        },
+        .text => |text_ev| {
+            const text = text_ev.slice();
+            if (text.len > 0) {
+                if (!ptyBufferedWrite(pty_ptr, text, write_buf, write_pending, evloop_fd)) {
+                    return false;
+                }
+            }
+        },
+        .paste => |paste_ev| {
+            const text = paste_ev.slice();
+            if (text.len > 0) {
+                if (!ptyBufferedWrite(pty_ptr, text, write_buf, write_pending, evloop_fd)) {
+                    return false;
+                }
+            }
+        },
+        .resize => |rsz| {
+            const new_cols = rsz.width / config.cell_width;
+            const new_rows = rsz.height / config.cell_height;
+            if (new_cols > 0 and new_rows > 0) {
+                term.resize(new_cols, new_rows) catch |err| {
+                    std.log.err("term resize: {}", .{err});
+                };
+                pty_ptr.resize(@intCast(new_cols), @intCast(new_rows)) catch |err| {
+                    std.log.err("pty resize: {}", .{err});
+                };
+                backend.resize(rsz.width, rsz.height) catch |err| {
+                    std.log.err("backend resize: {}", .{err});
+                };
+            }
+        },
+        .expose => {
+            const total = @as(usize, term.cols) * @as(usize, term.rows);
+            term.markDirtyRange(.{ .start = 0, .end = total });
+            term.all_dirty = true;
+        },
+        .focus_in => {
+            if (term.focus_events) {
+                if (!ptyBufferedWrite(pty_ptr, "\x1b[I", write_buf, write_pending, evloop_fd)) {
+                    return false;
+                }
+            }
+        },
+        .focus_out => {
+            if (term.focus_events) {
+                if (!ptyBufferedWrite(pty_ptr, "\x1b[O", write_buf, write_pending, evloop_fd)) {
+                    return false;
+                }
+            }
+        },
+        .close => {
+            return false;
+        },
+    }
+    return true;
+}
+
 // =============================================================================
 // Main
 // =============================================================================
@@ -529,78 +608,9 @@ pub fn main() !void {
                         // Backend events (X11, Wayland or macOS)
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
                             while (backend.pollEvents()) |event| {
-                                switch (event) {
-                                    .key => |key_ev| {
-                                        if (key_ev.pressed) {
-                                            const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm);
-                                            if (bytes.len > 0) {
-                                                if (!ptyBufferedWrite(&pty, bytes, &write_buf, &write_pending, evloop_fd)) {
-                                                    running = false;
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    },
-                                    .text => |text_ev| {
-                                        // IME committed text -- write UTF-8 directly to PTY
-                                        const text = text_ev.slice();
-                                        if (text.len > 0) {
-                                            if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .paste => |paste_ev| {
-                                        // Clipboard paste -- write to PTY
-                                        const text = paste_ev.slice();
-                                        if (text.len > 0) {
-                                            if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .resize => |rsz| {
-                                        const new_cols = rsz.width / config.cell_width;
-                                        const new_rows = rsz.height / config.cell_height;
-                                        if (new_cols > 0 and new_rows > 0) {
-                                            term.resize(new_cols, new_rows) catch |err| {
-                                                std.log.err("term resize: {}", .{err});
-                                            };
-                                            pty.resize(@intCast(new_cols), @intCast(new_rows)) catch |err| {
-                                                std.log.err("pty resize: {}", .{err});
-                                            };
-                                            backend.resize(rsz.width, rsz.height) catch |err| {
-                                                std.log.err("backend resize: {}", .{err});
-                                            };
-                                        }
-                                    },
-                                    .expose => {
-                                        // Force full redraw — mark all term cells dirty
-                                        const total = @as(usize, term.cols) * @as(usize, term.rows);
-                                        term.markDirtyRange(.{ .start = 0, .end = total });
-                                        term.all_dirty = true;
-                                    },
-                                    .focus_in => {
-                                        if (term.focus_events) {
-                                            if (!ptyBufferedWrite(&pty, "\x1b[I", &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .focus_out => {
-                                        if (term.focus_events) {
-                                            if (!ptyBufferedWrite(&pty, "\x1b[O", &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .close => {
-                                        running = false;
-                                    },
+                                if (!handleBackendEvent(event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
                                 }
                             }
                         }
@@ -678,75 +688,9 @@ pub fn main() !void {
                         // Backend events (X11, Wayland or macOS)
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
                             while (backend.pollEvents()) |event| {
-                                switch (event) {
-                                    .key => |key_ev| {
-                                        if (key_ev.pressed) {
-                                            const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm);
-                                            if (bytes.len > 0) {
-                                                if (!ptyBufferedWrite(&pty, bytes, &write_buf, &write_pending, evloop_fd)) {
-                                                    running = false;
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    },
-                                    .text => |text_ev| {
-                                        const text = text_ev.slice();
-                                        if (text.len > 0) {
-                                            if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .paste => |paste_ev| {
-                                        const text = paste_ev.slice();
-                                        if (text.len > 0) {
-                                            if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .resize => |rsz| {
-                                        const new_cols = rsz.width / config.cell_width;
-                                        const new_rows = rsz.height / config.cell_height;
-                                        if (new_cols > 0 and new_rows > 0) {
-                                            term.resize(new_cols, new_rows) catch |err| {
-                                                std.log.err("term resize: {}", .{err});
-                                            };
-                                            pty.resize(@intCast(new_cols), @intCast(new_rows)) catch |err| {
-                                                std.log.err("pty resize: {}", .{err});
-                                            };
-                                            backend.resize(rsz.width, rsz.height) catch |err| {
-                                                std.log.err("backend resize: {}", .{err});
-                                            };
-                                        }
-                                    },
-                                    .expose => {
-                                        const total = @as(usize, term.cols) * @as(usize, term.rows);
-                                        term.markDirtyRange(.{ .start = 0, .end = total });
-                                        term.all_dirty = true;
-                                    },
-                                    .focus_in => {
-                                        if (term.focus_events) {
-                                            if (!ptyBufferedWrite(&pty, "\x1b[I", &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .focus_out => {
-                                        if (term.focus_events) {
-                                            if (!ptyBufferedWrite(&pty, "\x1b[O", &write_buf, &write_pending, evloop_fd)) {
-                                                running = false;
-                                                break;
-                                            }
-                                        }
-                                    },
-                                    .close => {
-                                        running = false;
-                                    },
+                                if (!handleBackendEvent(event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
                                 }
                             }
                         }
@@ -771,75 +715,9 @@ pub fn main() !void {
             // never appears because Cocoa callbacks never fire.
             if (config.backend == .macos) {
                 while (backend.pollEvents()) |event| {
-                    switch (event) {
-                        .key => |key_ev| {
-                            if (key_ev.pressed) {
-                                const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm);
-                                if (bytes.len > 0) {
-                                    if (!ptyBufferedWrite(&pty, bytes, &write_buf, &write_pending, evloop_fd)) {
-                                        running = false;
-                                        break;
-                                    }
-                                }
-                            }
-                        },
-                        .text => |text_ev| {
-                            const text = text_ev.slice();
-                            if (text.len > 0) {
-                                if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
-                                    running = false;
-                                    break;
-                                }
-                            }
-                        },
-                        .paste => |paste_ev| {
-                            const text = paste_ev.slice();
-                            if (text.len > 0) {
-                                if (!ptyBufferedWrite(&pty, text, &write_buf, &write_pending, evloop_fd)) {
-                                    running = false;
-                                    break;
-                                }
-                            }
-                        },
-                        .resize => |rsz| {
-                            const new_cols = rsz.width / config.cell_width;
-                            const new_rows = rsz.height / config.cell_height;
-                            if (new_cols > 0 and new_rows > 0) {
-                                term.resize(new_cols, new_rows) catch |err| {
-                                    std.log.err("term resize: {}", .{err});
-                                };
-                                pty.resize(@intCast(new_cols), @intCast(new_rows)) catch |err| {
-                                    std.log.err("pty resize: {}", .{err});
-                                };
-                                backend.resize(rsz.width, rsz.height) catch |err| {
-                                    std.log.err("backend resize: {}", .{err});
-                                };
-                            }
-                        },
-                        .expose => {
-                            const total = @as(usize, term.cols) * @as(usize, term.rows);
-                            term.markDirtyRange(.{ .start = 0, .end = total });
-                            term.all_dirty = true;
-                        },
-                        .focus_in => {
-                            if (term.focus_events) {
-                                if (!ptyBufferedWrite(&pty, "\x1b[I", &write_buf, &write_pending, evloop_fd)) {
-                                    running = false;
-                                    break;
-                                }
-                            }
-                        },
-                        .focus_out => {
-                            if (term.focus_events) {
-                                if (!ptyBufferedWrite(&pty, "\x1b[O", &write_buf, &write_pending, evloop_fd)) {
-                                    running = false;
-                                    break;
-                                }
-                            }
-                        },
-                        .close => {
-                            running = false;
-                        },
+                    if (!handleBackendEvent(event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
+                        running = false;
+                        break;
                     }
                 }
             }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -18,7 +18,11 @@ const c = if (is_macos) @cImport({
     @cInclude("fcntl.h");
 }) else struct {};
 
-// ioctl constants
+// ioctl constants — stored as u32 for Linux (linux.ioctl takes u32).
+// On macOS, std.c.ioctl takes c_int, so callers use @bitCast(TIOCSWINSZ)
+// to reinterpret the u32 bit pattern as c_int. The kernel reads the
+// 32-bit request code from the low bits of the register regardless of
+// sign extension — this matches how C compilers pass ioctl constants.
 const TIOCSPTLCK: u32 = 0x40045431; // Linux only, not used on macOS
 const TIOCGPTN: u32 = 0x80045430; // Linux only, not used on macOS
 const TIOCSCTTY: u32 = if (is_macos) 0x20007461 else 0x540E;
@@ -244,17 +248,10 @@ pub const Pty = struct {
 
         // === Parent process ===
         // Set master_fd nonblocking
-        if (is_macos) {
+        {
             const F_GETFL = 3;
             const F_SETFL = 4;
-            const O_NONBLOCK: u32 = 0x0004; // macOS O_NONBLOCK
-            const cur_flags = try posix.fcntl(master_fd, F_GETFL, 0);
-            _ = try posix.fcntl(master_fd, F_SETFL, cur_flags | O_NONBLOCK);
-        } else {
-            // Linux: named constants (not in std.os.linux.F)
-            const F_GETFL = 3;
-            const F_SETFL = 4;
-            const O_NONBLOCK: u32 = 0x800;
+            const O_NONBLOCK: u32 = @bitCast(std.posix.O{ .NONBLOCK = true });
             const cur_flags = try posix.fcntl(master_fd, F_GETFL, 0);
             _ = try posix.fcntl(master_fd, F_SETFL, cur_flags | O_NONBLOCK);
         }


### PR DESCRIPTION
## Summary

Follow-up to #2 — addresses the code review feedback that came in after the PR was merged.

- Extract duplicated backend event switch into `handleBackendEvent()`, eliminating 3 copies (epoll, kqueue, macOS Cocoa pump) — net -125 lines
- Use `@bitCast(std.posix.O{ .NONBLOCK = true })` instead of hardcoded `O_NONBLOCK` constant, collapsing the identical macOS/Linux fcntl branches
- Add comment explaining why `@bitCast` on ioctl request constants is safe (kernel reads 32-bit pattern regardless of sign extension)

## Test plan
- [x] `zig build -Dbackend=macos -Doptimize=Debug` compiles clean
- [x] `zig build test` passes
- [x] Terminal still works on macOS (window, keyboard, resize)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * イベント処理ロジックを統合し、コード構造を簡素化しました。
  * プラットフォーム間のコード差異を統一化し、保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->