### PR TITLE
refactor: remove dead code, deduplicate switchScreen, fix selectiveErase TrueColor bug

### DIFF
--- a/src/font.zig
+++ b/src/font.zig
@@ -88,7 +88,10 @@ pub fn FontBlob(comptime blob: []const u8) type {
                 var valid: [CACHE_SIZE]bool = [_]bool{false} ** CACHE_SIZE;
             };
 
-            const idx = codepoint % S.CACHE_SIZE;
+            // XOR folding: mix high bits into low bits to reduce collisions
+            // for CJK ranges where codepoints differ only in upper bits
+            const folded = codepoint ^ (codepoint >> 8);
+            const idx = folded % S.CACHE_SIZE;
             if (S.valid[idx] and S.keys[idx] == codepoint) {
                 return S.vals[idx];
             }

--- a/src/render.zig
+++ b/src/render.zig
@@ -260,28 +260,6 @@ pub fn renderCell(
     }
 }
 
-pub fn renderCursor(
-    buffer: []u8,
-    stride: u32,
-    cell_x: u32,
-    cell_y: u32,
-    cell: Cell,
-    fg_rgb_override: ?[3]u8,
-    bg_rgb_override: ?[3]u8,
-    glyph: ?GlyphView,
-    comptime font_w: u32,
-    comptime font_h: u32,
-    comptime pixel_format: PixelFormat,
-    comptime wide: bool,
-    comptime scale: u32,
-) void {
-    var inverted = cell;
-    const tmp = inverted.fg;
-    inverted.fg = inverted.bg;
-    inverted.bg = tmp;
-    renderCell(buffer, stride, cell_x, cell_y, inverted, bg_rgb_override, fg_rgb_override, glyph, font_w, font_h, pixel_format, wide, scale, false);
-}
-
 // --- Tests ---
 
 test "Render: palette color 0 is black" {

--- a/src/term.zig
+++ b/src/term.zig
@@ -435,61 +435,39 @@ pub const Term = struct {
 
         const total = @as(usize, self.cols) * @as(usize, self.rows);
 
-        if (alt) {
-            // Lazy-allocate alt buffer
-            if (self.alt_cells == null) {
-                self.alt_cells = try self.allocator.alloc(Cell, total);
-                @memset(self.alt_cells.?, Cell{});
-                self.alt_row_map = try self.allocator.alloc(u32, self.rows);
-                for (0..self.rows) |i| self.alt_row_map.?[i] = @intCast(i);
-                self.alt_dirty = try std.DynamicBitSet.initFull(self.allocator, total);
-                self.alt_fg_rgb = try self.allocator.alloc(?[3]u8, total);
-                @memset(self.alt_fg_rgb.?, null);
-                self.alt_bg_rgb = try self.allocator.alloc(?[3]u8, total);
-                @memset(self.alt_bg_rgb.?, null);
-            }
-            // Swap main <-> alt (cells, row_map, dirty, TrueColor)
-            const tmp_cells = self.cells;
-            self.cells = self.alt_cells.?;
-            self.alt_cells = tmp_cells;
-
-            const tmp_rm = self.row_map;
-            self.row_map = self.alt_row_map.?;
-            self.alt_row_map = tmp_rm;
-
-            const tmp_dirty = self.dirty;
-            self.dirty = self.alt_dirty.?;
-            self.alt_dirty = tmp_dirty;
-
-            const tmp_fg = self.fg_rgb;
-            self.fg_rgb = self.alt_fg_rgb.?;
-            self.alt_fg_rgb = tmp_fg;
-
-            const tmp_bg = self.bg_rgb;
-            self.bg_rgb = self.alt_bg_rgb.?;
-            self.alt_bg_rgb = tmp_bg;
-        } else {
-            // Swap back
-            const tmp_cells = self.cells;
-            self.cells = self.alt_cells.?;
-            self.alt_cells = tmp_cells;
-
-            const tmp_rm = self.row_map;
-            self.row_map = self.alt_row_map.?;
-            self.alt_row_map = tmp_rm;
-
-            const tmp_dirty = self.dirty;
-            self.dirty = self.alt_dirty.?;
-            self.alt_dirty = tmp_dirty;
-
-            const tmp_fg = self.fg_rgb;
-            self.fg_rgb = self.alt_fg_rgb.?;
-            self.alt_fg_rgb = tmp_fg;
-
-            const tmp_bg = self.bg_rgb;
-            self.bg_rgb = self.alt_bg_rgb.?;
-            self.alt_bg_rgb = tmp_bg;
+        // Lazy-allocate alt buffer on first switch to alt screen
+        if (alt and self.alt_cells == null) {
+            self.alt_cells = try self.allocator.alloc(Cell, total);
+            @memset(self.alt_cells.?, Cell{});
+            self.alt_row_map = try self.allocator.alloc(u32, self.rows);
+            for (0..self.rows) |i| self.alt_row_map.?[i] = @intCast(i);
+            self.alt_dirty = try std.DynamicBitSet.initFull(self.allocator, total);
+            self.alt_fg_rgb = try self.allocator.alloc(?[3]u8, total);
+            @memset(self.alt_fg_rgb.?, null);
+            self.alt_bg_rgb = try self.allocator.alloc(?[3]u8, total);
+            @memset(self.alt_bg_rgb.?, null);
         }
+
+        // Swap main <-> alt (cells, row_map, dirty, TrueColor)
+        const tmp_cells = self.cells;
+        self.cells = self.alt_cells.?;
+        self.alt_cells = tmp_cells;
+
+        const tmp_rm = self.row_map;
+        self.row_map = self.alt_row_map.?;
+        self.alt_row_map = tmp_rm;
+
+        const tmp_dirty = self.dirty;
+        self.dirty = self.alt_dirty.?;
+        self.alt_dirty = tmp_dirty;
+
+        const tmp_fg = self.fg_rgb;
+        self.fg_rgb = self.alt_fg_rgb.?;
+        self.alt_fg_rgb = tmp_fg;
+
+        const tmp_bg = self.bg_rgb;
+        self.bg_rgb = self.alt_bg_rgb.?;
+        self.alt_bg_rgb = tmp_bg;
 
         self.is_alt_screen = alt;
         self.markDirtyRange(.{ .start = 0, .end = total });
@@ -806,14 +784,19 @@ pub const Term = struct {
     pub fn selectiveEraseDisplay(self: *Self, mode: u8) void {
         const cols: usize = self.cols;
         const blank = self.blankCell();
+        const bg_rgb_val: ?[3]u8 = self.current_bg_rgb;
         switch (mode) {
             0 => {
                 for (self.cursor_y..self.rows) |y| {
                     const phys = self.row_map[y];
                     const from: usize = if (y == self.cursor_y) self.cursor_x else 0;
                     for (from..cols) |x| {
-                        if (!self.cells[phys * cols + x].attrs.protected)
-                            self.cells[phys * cols + x] = blank;
+                        const idx = phys * cols + x;
+                        if (!self.cells[idx].attrs.protected) {
+                            self.cells[idx] = blank;
+                            self.fg_rgb[idx] = null;
+                            self.bg_rgb[idx] = bg_rgb_val;
+                        }
                     }
                 }
                 self.markDirtyRange(.{ .start = @as(usize, self.cursor_y) * cols + self.cursor_x, .end = @as(usize, self.rows) * cols });
@@ -823,8 +806,12 @@ pub const Term = struct {
                     const phys = self.row_map[y];
                     const to: usize = if (y == self.cursor_y) self.cursor_x + 1 else cols;
                     for (0..to) |x| {
-                        if (!self.cells[phys * cols + x].attrs.protected)
-                            self.cells[phys * cols + x] = blank;
+                        const idx = phys * cols + x;
+                        if (!self.cells[idx].attrs.protected) {
+                            self.cells[idx] = blank;
+                            self.fg_rgb[idx] = null;
+                            self.bg_rgb[idx] = bg_rgb_val;
+                        }
                     }
                 }
                 self.markDirtyRange(.{ .start = 0, .end = @as(usize, self.cursor_y) * cols + self.cursor_x + 1 });
@@ -833,8 +820,12 @@ pub const Term = struct {
                 for (0..self.rows) |y| {
                     const phys = self.row_map[y];
                     for (0..cols) |x| {
-                        if (!self.cells[phys * cols + x].attrs.protected)
-                            self.cells[phys * cols + x] = blank;
+                        const idx = phys * cols + x;
+                        if (!self.cells[idx].attrs.protected) {
+                            self.cells[idx] = blank;
+                            self.fg_rgb[idx] = null;
+                            self.bg_rgb[idx] = bg_rgb_val;
+                        }
                     }
                 }
                 self.markDirtyRange(.{ .start = 0, .end = @as(usize, self.cols) * @as(usize, self.rows) });
@@ -848,62 +839,44 @@ pub const Term = struct {
         const cols: usize = self.cols;
         const phys = self.row_map[self.cursor_y];
         const blank = self.blankCell();
+        const bg_rgb_val: ?[3]u8 = self.current_bg_rgb;
         const row_start = @as(usize, self.cursor_y) * cols;
         switch (mode) {
             0 => {
                 for (self.cursor_x..self.cols) |x| {
-                    if (!self.cells[phys * cols + x].attrs.protected)
-                        self.cells[phys * cols + x] = blank;
+                    const idx = phys * cols + x;
+                    if (!self.cells[idx].attrs.protected) {
+                        self.cells[idx] = blank;
+                        self.fg_rgb[idx] = null;
+                        self.bg_rgb[idx] = bg_rgb_val;
+                    }
                 }
                 self.markDirtyRange(.{ .start = row_start + self.cursor_x, .end = row_start + cols });
             },
             1 => {
                 for (0..self.cursor_x + 1) |x| {
-                    if (!self.cells[phys * cols + x].attrs.protected)
-                        self.cells[phys * cols + x] = blank;
+                    const idx = phys * cols + x;
+                    if (!self.cells[idx].attrs.protected) {
+                        self.cells[idx] = blank;
+                        self.fg_rgb[idx] = null;
+                        self.bg_rgb[idx] = bg_rgb_val;
+                    }
                 }
                 self.markDirtyRange(.{ .start = row_start, .end = row_start + self.cursor_x + 1 });
             },
             2 => {
                 for (0..cols) |x| {
-                    if (!self.cells[phys * cols + x].attrs.protected)
-                        self.cells[phys * cols + x] = blank;
+                    const idx = phys * cols + x;
+                    if (!self.cells[idx].attrs.protected) {
+                        self.cells[idx] = blank;
+                        self.fg_rgb[idx] = null;
+                        self.bg_rgb[idx] = bg_rgb_val;
+                    }
                 }
                 self.markDirtyRange(.{ .start = row_start, .end = row_start + cols });
             },
             else => {},
         }
-    }
-
-    /// Clear RGB entries for a physical row (O(1) memset)
-    fn clearRgbRow(self: *Self, phys_row: usize) void {
-        const cols: usize = self.cols;
-        const start = phys_row * cols;
-        @memset(self.fg_rgb[start .. start + cols], null);
-        @memset(self.bg_rgb[start .. start + cols], null);
-    }
-
-    /// Clear RGB entries for a physical index range (O(1) memset)
-    fn clearRgbPhysRange(self: *Self, start: usize, end: usize) void {
-        @memset(self.fg_rgb[start..end], null);
-        @memset(self.bg_rgb[start..end], null);
-    }
-
-    /// Clear RGB entries for logical rows [y_start, y_end)
-    fn clearRgbRange(self: *Self, y_start: usize, y_end: usize, _: usize) void {
-        const cols: usize = self.cols;
-        for (y_start..y_end) |y| {
-            const phys = self.row_map[y];
-            const start = phys * cols;
-            @memset(self.fg_rgb[start .. start + cols], null);
-            @memset(self.bg_rgb[start .. start + cols], null);
-        }
-    }
-
-    /// Clear all TrueColor entries.
-    fn clearAllRgb(self: *Self) void {
-        @memset(self.fg_rgb, null);
-        @memset(self.bg_rgb, null);
     }
 
     // TrueColor helpers (indexed by physical cell position)


### PR DESCRIPTION
- Remove 4 unused functions in term.zig (clearRgbRow, clearRgbPhysRange,
  clearRgbRange, clearAllRgb) and unused renderCursor in render.zig
- Deduplicate switchScreen: alt=true and alt=false branches performed
  identical swaps; consolidated into a single code path (-20 lines)
- Fix selectiveEraseDisplay/selectiveEraseLine not clearing fg_rgb/bg_rgb
  arrays when erasing cells (TrueColor ghost artifacts)
- Improve font cache hash: XOR folding reduces collisions for CJK
  codepoints that differ only in upper bits

Net: -46 lines

https://claude.ai/code/session_01BZCKFGbKtuKkqZB5BQbRe3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * セル削除時のカラー状態の処理を改善し、TrueColor表示の正確性を向上

* **Performance**
  * 文字キャッシュ検索アルゴリズムを最適化

* **Refactor**
  * レンダリング機能の内部構造を整理
  * スクリーン切り替え動作を簡潔化
  * 不要なコード削除によるメンテナンス性向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->