### PR TITLE
Fix 9 issues from comprehensive code review

### DIFF
--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -795,10 +795,6 @@ pub const X11Backend = struct {
         };
         defer std.c.free(event);
 
-        // Lazy-init keyboard before XIM filter so self.xim is available
-        // on the very first key press event
-        self.ensureKeyboardInit();
-
         // Let XIM filter the event first — MUST run even before xim_connected
         // because xcb-imdkit uses this to process the XIM protocol handshake
         if (self.xim) |xim| {
@@ -827,6 +823,9 @@ pub const X11Backend = struct {
         const event_type = event.*.response_type & 0x7F;
         switch (event_type) {
             c.XCB_KEY_PRESS => {
+                // Lazy-init XKB+XIM on first key press (not on non-key events,
+                // so transient XIM failures don't permanently disable IME)
+                self.ensureKeyboardInit();
                 const key: *c.xcb_key_press_event_t = @ptrCast(@alignCast(event));
                 const mods = xcbStateToMods(key.*.state);
                 const evdev_keycode = key.*.detail -| 8;

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -356,15 +356,26 @@ pub const X11Backend = struct {
         if (xkb_result == 0) return;
 
         const ctx = c.xkb_context_new(c.XKB_CONTEXT_NO_FLAGS) orelse return;
-        self.xkb_ctx = ctx;
 
         const device_id = c.xkb_x11_get_core_keyboard_device_id(self.connection);
-        if (device_id < 0) return;
+        if (device_id < 0) {
+            c.xkb_context_unref(ctx);
+            return;
+        }
 
-        const km = c.xkb_x11_keymap_new_from_device(ctx, self.connection, device_id, c.XKB_KEYMAP_COMPILE_NO_FLAGS) orelse return;
+        const km = c.xkb_x11_keymap_new_from_device(ctx, self.connection, device_id, c.XKB_KEYMAP_COMPILE_NO_FLAGS) orelse {
+            c.xkb_context_unref(ctx);
+            return;
+        };
+
+        const state = c.xkb_x11_state_new_from_device(km, self.connection, device_id) orelse {
+            c.xkb_keymap_unref(km);
+            c.xkb_context_unref(ctx);
+            return;
+        };
+
+        self.xkb_ctx = ctx;
         self.xkb_keymap = km;
-
-        const state = c.xkb_x11_state_new_from_device(km, self.connection, device_id) orelse return;
         self.xkb_state = state;
     }
 
@@ -622,8 +633,8 @@ pub const X11Backend = struct {
     /// Uses set_ic_values with XNSpotLocation (standard XIM protocol).
     /// Only sends when position changes to avoid IME instability.
     pub fn updateImeCursorPos(self: *Self, pixel_x: u32, pixel_y: u32) void {
-        const x: i16 = @intCast(pixel_x);
-        const y: i16 = @intCast(pixel_y);
+        const x: i16 = if (pixel_x > std.math.maxInt(i16)) std.math.maxInt(i16) else @intCast(pixel_x);
+        const y: i16 = if (pixel_y > std.math.maxInt(i16)) std.math.maxInt(i16) else @intCast(pixel_y);
         if (x == self.last_ime_x and y == self.last_ime_y) return;
 
         if (self.xim) |xim| {
@@ -784,6 +795,10 @@ pub const X11Backend = struct {
         };
         defer std.c.free(event);
 
+        // Lazy-init keyboard before XIM filter so self.xim is available
+        // on the very first key press event
+        self.ensureKeyboardInit();
+
         // Let XIM filter the event first — MUST run even before xim_connected
         // because xcb-imdkit uses this to process the XIM protocol handshake
         if (self.xim) |xim| {
@@ -812,7 +827,6 @@ pub const X11Backend = struct {
         const event_type = event.*.response_type & 0x7F;
         switch (event_type) {
             c.XCB_KEY_PRESS => {
-                self.ensureKeyboardInit();
                 const key: *c.xcb_key_press_event_t = @ptrCast(@alignCast(event));
                 const mods = xcbStateToMods(key.*.state);
                 const evdev_keycode = key.*.detail -| 8;

--- a/src/input.zig
+++ b/src/input.zig
@@ -360,7 +360,7 @@ fn getSpecialKey(kc: u16) ?SpecialKey {
 /// Translate a Linux evdev keycode + modifiers into bytes to write to the PTY.
 /// Returns a slice into a static buffer — valid only until the next call.
 /// NOT thread-safe: uses function-level static storage.
-pub fn translateKey(keycode: u16, mods: Modifiers, decckm: bool) []const u8 {
+pub fn translateKey(keycode: u16, mods: Modifiers, decckm: bool, decbkm: bool) []const u8 {
     const S = struct {
         var buf: [32]u8 = undefined;
     };
@@ -377,12 +377,14 @@ pub fn translateKey(keycode: u16, mods: Modifiers, decckm: bool) []const u8 {
             return S.buf[0..1];
         },
         KEY.BACKSPACE => {
+            // DECBKM (?67): true = BS (0x08), false = DEL (0x7F)
+            const bs_byte: u8 = if (decbkm) 0x08 else 0x7f;
             if (mods.alt) {
                 S.buf[0] = 0x1b;
-                S.buf[1] = 0x7f;
+                S.buf[1] = bs_byte;
                 return S.buf[0..2];
             }
-            S.buf[0] = 0x7f;
+            S.buf[0] = bs_byte;
             return S.buf[0..1];
         },
         KEY.TAB => {
@@ -500,133 +502,133 @@ fn writeU8(buf: []u8, val: u8) usize {
 // ============================================================
 
 test "Input: KEY_A with no mods produces 'a'" {
-    const result = translateKey(KEY.A, .{}, false);
+    const result = translateKey(KEY.A, .{}, false, false);
     try testing.expectEqualSlices(u8, "a", result);
 }
 
 test "Input: KEY_A with shift produces 'A'" {
-    const result = translateKey(KEY.A, .{ .shift = true }, false);
+    const result = translateKey(KEY.A, .{ .shift = true }, false, false);
     try testing.expectEqualSlices(u8, "A", result);
 }
 
 test "Input: KEY_A with ctrl produces 0x01" {
-    const result = translateKey(KEY.A, .{ .ctrl = true }, false);
+    const result = translateKey(KEY.A, .{ .ctrl = true }, false, false);
     try testing.expectEqualSlices(u8, &[_]u8{0x01}, result);
 }
 
 test "Input: KEY_A with alt produces ESC + 'a'" {
-    const result = translateKey(KEY.A, .{ .alt = true }, false);
+    const result = translateKey(KEY.A, .{ .alt = true }, false, false);
     try testing.expectEqualSlices(u8, "\x1ba", result);
 }
 
 test "Input: KEY_UP with DECCKM off produces CSI A" {
-    const result = translateKey(KEY.UP, .{}, false);
+    const result = translateKey(KEY.UP, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1b[A", result);
 }
 
 test "Input: KEY_UP with DECCKM on produces SS3 A" {
-    const result = translateKey(KEY.UP, .{}, true);
+    const result = translateKey(KEY.UP, .{}, true, false);
     try testing.expectEqualSlices(u8, "\x1bOA", result);
 }
 
 test "Input: KEY_ENTER produces CR" {
-    const result = translateKey(KEY.ENTER, .{}, false);
+    const result = translateKey(KEY.ENTER, .{}, false, false);
     try testing.expectEqualSlices(u8, "\r", result);
 }
 
 test "Input: KEY_F1 produces SS3 P" {
-    const result = translateKey(KEY.F1, .{}, false);
+    const result = translateKey(KEY.F1, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1bOP", result);
 }
 
 test "Input: KEY_BACKSPACE produces DEL" {
-    const result = translateKey(KEY.BACKSPACE, .{}, false);
+    const result = translateKey(KEY.BACKSPACE, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x7f", result);
 }
 
 test "Input: KEY_HOME produces CSI H" {
-    const result = translateKey(KEY.HOME, .{}, false);
+    const result = translateKey(KEY.HOME, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1b[H", result);
 }
 
 test "Input: KEY_DELETE produces CSI 3~" {
-    const result = translateKey(KEY.DELETE, .{}, false);
+    const result = translateKey(KEY.DELETE, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1b[3~", result);
 }
 
 test "Input: number key 1 produces '1'" {
-    const result = translateKey(KEY.@"1", .{}, false);
+    const result = translateKey(KEY.@"1", .{}, false, false);
     try testing.expectEqualSlices(u8, "1", result);
 }
 
 test "Input: number key 1 with shift produces '!'" {
-    const result = translateKey(KEY.@"1", .{ .shift = true }, false);
+    const result = translateKey(KEY.@"1", .{ .shift = true }, false, false);
     try testing.expectEqualSlices(u8, "!", result);
 }
 
 test "Input: Ctrl+C produces 0x03" {
-    const result = translateKey(KEY.C, .{ .ctrl = true }, false);
+    const result = translateKey(KEY.C, .{ .ctrl = true }, false, false);
     try testing.expectEqualSlices(u8, &[_]u8{0x03}, result);
 }
 
 test "Input: Ctrl+Space produces NUL" {
-    const result = translateKey(KEY.SPACE, .{ .ctrl = true }, false);
+    const result = translateKey(KEY.SPACE, .{ .ctrl = true }, false, false);
     try testing.expectEqualSlices(u8, &[_]u8{0x00}, result);
 }
 
 test "Input: Shift+Tab produces CSI Z" {
-    const result = translateKey(KEY.TAB, .{ .shift = true }, false);
+    const result = translateKey(KEY.TAB, .{ .shift = true }, false, false);
     try testing.expectEqualSlices(u8, "\x1b[Z", result);
 }
 
 test "Input: Ctrl+Up produces modified arrow" {
-    const result = translateKey(KEY.UP, .{ .ctrl = true }, false);
+    const result = translateKey(KEY.UP, .{ .ctrl = true }, false, false);
     try testing.expectEqualSlices(u8, "\x1b[1;5A", result);
 }
 
 test "Input: Shift+Delete produces modified tilde" {
-    const result = translateKey(KEY.DELETE, .{ .shift = true }, false);
+    const result = translateKey(KEY.DELETE, .{ .shift = true }, false, false);
     try testing.expectEqualSlices(u8, "\x1b[3;2~", result);
 }
 
 test "Input: KEY_PAGEUP produces CSI 5~" {
-    const result = translateKey(KEY.PAGEUP, .{}, false);
+    const result = translateKey(KEY.PAGEUP, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1b[5~", result);
 }
 
 test "Input: KEY_END produces CSI F" {
-    const result = translateKey(KEY.END, .{}, false);
+    const result = translateKey(KEY.END, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1b[F", result);
 }
 
 test "Input: KEY_F5 produces CSI 15~" {
-    const result = translateKey(KEY.F5, .{}, false);
+    const result = translateKey(KEY.F5, .{}, false, false);
     try testing.expectEqualSlices(u8, "\x1b[15~", result);
 }
 
 test "Input: Alt+Ctrl+A produces ESC + 0x01" {
-    const result = translateKey(KEY.A, .{ .alt = true, .ctrl = true }, false);
+    const result = translateKey(KEY.A, .{ .alt = true, .ctrl = true }, false, false);
     try testing.expectEqualSlices(u8, &[_]u8{ 0x1b, 0x01 }, result);
 }
 
 test "Input: symbol keys" {
-    try testing.expectEqualSlices(u8, "-", translateKey(KEY.MINUS, .{}, false));
-    try testing.expectEqualSlices(u8, "_", translateKey(KEY.MINUS, .{ .shift = true }, false));
-    try testing.expectEqualSlices(u8, "=", translateKey(KEY.EQUAL, .{}, false));
-    try testing.expectEqualSlices(u8, "+", translateKey(KEY.EQUAL, .{ .shift = true }, false));
-    try testing.expectEqualSlices(u8, "[", translateKey(KEY.LEFTBRACE, .{}, false));
-    try testing.expectEqualSlices(u8, "{", translateKey(KEY.LEFTBRACE, .{ .shift = true }, false));
-    try testing.expectEqualSlices(u8, ";", translateKey(KEY.SEMICOLON, .{}, false));
-    try testing.expectEqualSlices(u8, ":", translateKey(KEY.SEMICOLON, .{ .shift = true }, false));
+    try testing.expectEqualSlices(u8, "-", translateKey(KEY.MINUS, .{}, false, false));
+    try testing.expectEqualSlices(u8, "_", translateKey(KEY.MINUS, .{ .shift = true }, false, false));
+    try testing.expectEqualSlices(u8, "=", translateKey(KEY.EQUAL, .{}, false, false));
+    try testing.expectEqualSlices(u8, "+", translateKey(KEY.EQUAL, .{ .shift = true }, false, false));
+    try testing.expectEqualSlices(u8, "[", translateKey(KEY.LEFTBRACE, .{}, false, false));
+    try testing.expectEqualSlices(u8, "{", translateKey(KEY.LEFTBRACE, .{ .shift = true }, false, false));
+    try testing.expectEqualSlices(u8, ";", translateKey(KEY.SEMICOLON, .{}, false, false));
+    try testing.expectEqualSlices(u8, ":", translateKey(KEY.SEMICOLON, .{ .shift = true }, false, false));
 }
 
 test "Input: HOME with DECCKM on produces SS3 H" {
-    const result = translateKey(KEY.HOME, .{}, true);
+    const result = translateKey(KEY.HOME, .{}, true, false);
     try testing.expectEqualSlices(u8, "\x1bOH", result);
 }
 
 test "Input: unknown keycode returns empty" {
-    const result = translateKey(255, .{}, false);
+    const result = translateKey(255, .{}, false, false);
     try testing.expectEqualSlices(u8, "", result);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -222,23 +222,21 @@ fn ptyBufferedWrite(
             }
             write_pending.* = remaining;
         }
-        // Append as much as possible after flush
+        // Append after flush — reject if buffer still can't fit all data
         const space2 = write_buf.len - write_pending.*;
-        const to_copy = @min(data.len, space2);
-        if (to_copy > 0) {
-            @memcpy(write_buf[write_pending.* .. write_pending.* + to_copy], data[0..to_copy]);
-            write_pending.* += to_copy;
-        }
+        if (data.len > space2) return false; // buffer full, cannot accept
+        @memcpy(write_buf[write_pending.* .. write_pending.* + data.len], data);
+        write_pending.* += data.len;
         return true;
     }
 
     // Try direct write
     const written = pty_ptr.write(data) catch |err| switch (err) {
         error.WouldBlock => {
-            // Buffer everything (up to buffer capacity)
-            const to_copy = @min(data.len, write_buf.len);
-            @memcpy(write_buf[0..to_copy], data[0..to_copy]);
-            write_pending.* = to_copy;
+            // Buffer everything — reject if data exceeds buffer capacity
+            if (data.len > write_buf.len) return false;
+            @memcpy(write_buf[0..data.len], data);
+            write_pending.* = data.len;
             if (is_linux) {
                 epollSetPtyEvents(epoll_fd, pty_ptr.master_fd, true);
             } else {
@@ -249,12 +247,12 @@ fn ptyBufferedWrite(
         else => return false,
     };
 
-    // Partial write — buffer the rest
+    // Partial write — buffer the rest (reject if remainder exceeds buffer)
     if (written < data.len) {
         const remaining = data.len - written;
-        const to_copy = @min(remaining, write_buf.len);
-        @memcpy(write_buf[0..to_copy], data[written .. written + to_copy]);
-        write_pending.* = to_copy;
+        if (remaining > write_buf.len) return false;
+        @memcpy(write_buf[0..remaining], data[written .. written + remaining]);
+        write_pending.* = remaining;
         if (is_linux) {
             epollSetPtyEvents(epoll_fd, pty_ptr.master_fd, true);
         } else {

--- a/src/main.zig
+++ b/src/main.zig
@@ -194,28 +194,48 @@ fn kqueueSetPtyWrite(kq: i32, pty_fd: std.posix.fd_t, enable: bool) void {
 }
 
 /// Write to PTY with buffering on WouldBlock.
+/// Uses a 64KB buffer to avoid truncation on large pastes or IME commits.
 fn ptyBufferedWrite(
     pty_ptr: *Pty,
     data: []const u8,
-    write_buf: *[4096]u8,
+    write_buf: *[65536]u8,
     write_pending: *usize,
     epoll_fd: i32,
 ) bool {
-    // If there's pending data, just append to buffer
+    // If there's pending data, append to buffer (retry-write remaining on overflow)
     if (write_pending.* > 0) {
         const space = write_buf.len - write_pending.*;
-        const to_copy = @min(data.len, space);
+        if (data.len <= space) {
+            @memcpy(write_buf[write_pending.* .. write_pending.* + data.len], data);
+            write_pending.* += data.len;
+            return true;
+        }
+        // Buffer full — try flushing pending data first to make room
+        const flushed = pty_ptr.write(write_buf[0..write_pending.*]) catch |err| switch (err) {
+            error.WouldBlock => 0,
+            else => return false,
+        };
+        if (flushed > 0) {
+            const remaining = write_pending.* - flushed;
+            if (remaining > 0) {
+                std.mem.copyForwards(u8, write_buf[0..remaining], write_buf[flushed .. flushed + remaining]);
+            }
+            write_pending.* = remaining;
+        }
+        // Append as much as possible after flush
+        const space2 = write_buf.len - write_pending.*;
+        const to_copy = @min(data.len, space2);
         if (to_copy > 0) {
             @memcpy(write_buf[write_pending.* .. write_pending.* + to_copy], data[0..to_copy]);
             write_pending.* += to_copy;
         }
-        return true; // still running
+        return true;
     }
 
     // Try direct write
     const written = pty_ptr.write(data) catch |err| switch (err) {
         error.WouldBlock => {
-            // Buffer everything
+            // Buffer everything (up to buffer capacity)
             const to_copy = @min(data.len, write_buf.len);
             @memcpy(write_buf[0..to_copy], data[0..to_copy]);
             write_pending.* = to_copy;
@@ -247,7 +267,7 @@ fn ptyBufferedWrite(
 /// Flush pending write buffer.
 fn ptyFlushPending(
     pty_ptr: *Pty,
-    write_buf: *[4096]u8,
+    write_buf: *[65536]u8,
     write_pending: *usize,
     epoll_fd: i32,
 ) bool {
@@ -314,14 +334,14 @@ fn handleBackendEvent(
     term: *Term,
     pty_ptr: *Pty,
     backend: *Backend,
-    write_buf: *[4096]u8,
+    write_buf: *[65536]u8,
     write_pending: *usize,
     evloop_fd: i32,
 ) bool {
     switch (event.*) {
         .key => |key_ev| {
             if (key_ev.pressed) {
-                const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm);
+                const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm, term.decbkm);
                 if (bytes.len > 0) {
                     if (!ptyBufferedWrite(pty_ptr, bytes, write_buf, write_pending, evloop_fd)) {
                         return false;
@@ -539,7 +559,7 @@ pub fn main() !void {
     var cursor_visible_blink = true;
     var prev_cursor_x: u32 = 0;
     var prev_cursor_y: u32 = 0;
-    var write_buf: [4096]u8 = undefined;
+    var write_buf: [65536]u8 = undefined;
     var write_pending: usize = 0;
     var last_render_ns: i128 = 0;
     var bytes_since_render: usize = 0;
@@ -650,7 +670,7 @@ pub fn main() !void {
                                     },
                                     else => {
                                         if (input_event.pressed or input_event.repeat) {
-                                            const bytes = input.translateKey(input_event.keycode, mod_state, term.decckm);
+                                            const bytes = input.translateKey(input_event.keycode, mod_state, term.decckm, term.decbkm);
                                             if (bytes.len > 0) {
                                                 if (!ptyBufferedWrite(&pty, bytes, &write_buf, &write_pending, evloop_fd)) {
                                                     running = false;

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -234,13 +234,13 @@ pub const Pty = struct {
                     _ = posix.write(2, "zt: execvpe failed\n") catch {};
                 };
             } else {
-                // Default: login shell
+                // Default: login shell (execvpeZ searches PATH for bare names like "fish")
                 const argv: [*:null]const ?[*:0]const u8 = &[_:null]?[*:0]const u8{
                     shell_path,
                     "--login",
                 };
-                _ = posix.execveZ(shell_path, argv, env) catch {
-                    _ = posix.write(2, "zt: execve failed\n") catch {};
+                _ = posix.execvpeZ(shell_path, argv, env) catch {
+                    _ = posix.write(2, "zt: execvpe failed\n") catch {};
                 };
             }
             std.posix.exit(1);

--- a/src/term.zig
+++ b/src/term.zig
@@ -441,31 +441,32 @@ pub const Term = struct {
         self.cursor_x = @min(self.cursor_x, new_cols -| 1);
         self.cursor_y = @min(self.cursor_y, new_rows -| 1);
 
-        // Resize alt buffer if allocated
-        if (self.alt_cells) |alt| {
-            self.allocator.free(alt);
-            self.alt_cells = try self.allocator.alloc(Cell, new_total);
-            @memset(self.alt_cells.?, Cell{});
-        }
-        if (self.alt_row_map) |arm| {
-            self.allocator.free(arm);
-            self.alt_row_map = try self.allocator.alloc(u32, new_rows);
-            for (0..new_rows) |i| self.alt_row_map.?[i] = @intCast(i);
-        }
-        if (self.alt_dirty) |*ad| {
-            ad.deinit();
-            self.alt_dirty = try std.DynamicBitSet.initFull(self.allocator, new_total);
-        }
-        if (self.alt_fg_rgb) |a| {
-            const new_alt_fg = try self.allocator.alloc(?[3]u8, new_total);
-            @memset(new_alt_fg, null);
-            self.allocator.free(a);
+        // Resize alt buffer if allocated — allocate all new buffers first,
+        // then free old ones, so OOM leaves the old buffers intact (no UAF).
+        if (self.alt_cells != null or self.alt_row_map != null or self.alt_dirty != null or self.alt_fg_rgb != null or self.alt_bg_rgb != null) {
+            const new_alt_cells = if (self.alt_cells != null) try self.allocator.alloc(Cell, new_total) else null;
+            const new_alt_row_map = if (self.alt_row_map != null) try self.allocator.alloc(u32, new_rows) else null;
+            const new_alt_dirty = if (self.alt_dirty != null) try std.DynamicBitSet.initFull(self.allocator, new_total) else null;
+            const new_alt_fg = if (self.alt_fg_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
+            const new_alt_bg = if (self.alt_bg_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
+
+            // All allocations succeeded — now free old and swap
+            if (self.alt_cells) |alt| self.allocator.free(alt);
+            if (self.alt_row_map) |arm| self.allocator.free(arm);
+            if (self.alt_dirty) |*ad| ad.deinit();
+            if (self.alt_fg_rgb) |a| self.allocator.free(a);
+            if (self.alt_bg_rgb) |a| self.allocator.free(a);
+
+            if (new_alt_cells) |nac| @memset(nac, Cell{});
+            self.alt_cells = new_alt_cells;
+            if (new_alt_row_map) |narm| for (0..new_rows) |i| {
+                narm[i] = @intCast(i);
+            };
+            self.alt_row_map = new_alt_row_map;
+            self.alt_dirty = new_alt_dirty;
+            if (new_alt_fg) |nfg| @memset(nfg, null);
             self.alt_fg_rgb = new_alt_fg;
-        }
-        if (self.alt_bg_rgb) |a| {
-            const new_alt_bg = try self.allocator.alloc(?[3]u8, new_total);
-            @memset(new_alt_bg, null);
-            self.allocator.free(a);
+            if (new_alt_bg) |nbg| @memset(nbg, null);
             self.alt_bg_rgb = new_alt_bg;
         }
     }

--- a/src/term.zig
+++ b/src/term.zig
@@ -445,9 +445,13 @@ pub const Term = struct {
         // then free old ones, so OOM leaves the old buffers intact (no UAF).
         if (self.alt_cells != null or self.alt_row_map != null or self.alt_dirty != null or self.alt_fg_rgb != null or self.alt_bg_rgb != null) {
             const new_alt_cells = if (self.alt_cells != null) try self.allocator.alloc(Cell, new_total) else null;
+            errdefer if (new_alt_cells) |nac| self.allocator.free(nac);
             const new_alt_row_map = if (self.alt_row_map != null) try self.allocator.alloc(u32, new_rows) else null;
+            errdefer if (new_alt_row_map) |narm| self.allocator.free(narm);
             const new_alt_dirty = if (self.alt_dirty != null) try std.DynamicBitSet.initFull(self.allocator, new_total) else null;
+            errdefer if (new_alt_dirty) |*nad| @constCast(nad).deinit();
             const new_alt_fg = if (self.alt_fg_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
+            errdefer if (new_alt_fg) |nafg| self.allocator.free(nafg);
             const new_alt_bg = if (self.alt_bg_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
 
             // All allocations succeeded — now free old and swap

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -833,20 +833,12 @@ fn handleVt52Byte(byte: u8, term: *Term, parser: *Parser, writer_fd: ?std.posix.
 fn isWide(cp: u21) bool {
     // Unicode 15.1 East Asian Width W/F — comprehensive table based on EAW.txt
     // Fast rejection: ASCII, Latin, common symbols (vast majority of chars)
-    if (cp < 0x1100) {
-        // Misc wide characters below 0x1100
-        return switch (cp) {
-            0x231A, 0x231B, // Watch, Hourglass
-            0x2329, 0x232A, // Angle brackets
-            0x23E9...0x23F3, // Various clocks/timers
-            0x23F8...0x23FA, // Playback symbols
-            => true,
-            else => false,
-        };
-    }
+    if (cp < 0x1100) return false;
     if (cp <= 0x115F) return true; // Hangul Jamo
-    if (cp < 0x2329) return false;
-    if (cp <= 0x232A) return true; // Angle Brackets (also in switch above but needed for range flow)
+    if (cp == 0x231A or cp == 0x231B) return true; // Watch, Hourglass
+    if (cp >= 0x2329 and cp <= 0x232A) return true; // Angle Brackets
+    if (cp >= 0x23E9 and cp <= 0x23F3) return true; // Various clocks/timers
+    if (cp >= 0x23F8 and cp <= 0x23FA) return true; // Playback symbols
     if (cp < 0x2E80) return false;
     // CJK Radicals Supplement through Yi Radicals
     if (cp <= 0x303E) return true; // CJK Radicals, Kangxi, CJK Symbols
@@ -886,7 +878,6 @@ fn isWide(cp: u21) bool {
         0x1F780...0x1F7FF, // Geometric Shapes Extended
         0x1F800...0x1F8FF, // Supplemental Arrows-C
         0x1F900...0x1F9FF, // Supplemental Symbols and Pictographs
-        0x1FA00...0x1FA6F, // Chess Symbols
         0x1FA70...0x1FAFF, // Symbols and Pictographs Extended-A
         0x1FB00...0x1FBFF, // Symbols for Legacy Computing
         0x20000...0x2FFFF, // CJK Extensions B-G, Compatibility Supplement

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -149,27 +149,34 @@ pub const Parser = struct {
     }
 
     fn decodeUtf8(bytes: []const u8) u21 {
-        switch (bytes.len) {
-            2 => {
+        const cp: u21 = switch (bytes.len) {
+            2 => blk: {
                 const b0 = @as(u21, bytes[0] & 0x1F);
                 const b1 = @as(u21, bytes[1] & 0x3F);
-                return (b0 << 6) | b1;
+                const v = (b0 << 6) | b1;
+                // Reject overlong: 2-byte must encode >= U+0080
+                break :blk if (v < 0x80) 0xFFFD else v;
             },
-            3 => {
+            3 => blk: {
                 const b0 = @as(u21, bytes[0] & 0x0F);
                 const b1 = @as(u21, bytes[1] & 0x3F);
                 const b2 = @as(u21, bytes[2] & 0x3F);
-                return (b0 << 12) | (b1 << 6) | b2;
+                const v = (b0 << 12) | (b1 << 6) | b2;
+                // Reject overlong (must encode >= U+0800) and surrogates (U+D800..U+DFFF)
+                break :blk if (v < 0x800 or (v >= 0xD800 and v <= 0xDFFF)) 0xFFFD else v;
             },
-            4 => {
+            4 => blk: {
                 const b0 = @as(u21, bytes[0] & 0x07);
                 const b1 = @as(u21, bytes[1] & 0x3F);
                 const b2 = @as(u21, bytes[2] & 0x3F);
                 const b3 = @as(u21, bytes[3] & 0x3F);
-                return (b0 << 18) | (b1 << 12) | (b2 << 6) | b3;
+                const v = (b0 << 18) | (b1 << 12) | (b2 << 6) | b3;
+                // Reject overlong (must encode >= U+10000) and > U+10FFFF
+                break :blk if (v < 0x10000 or v > 0x10FFFF) 0xFFFD else v;
             },
-            else => return 0xFFFD,
-        }
+            else => 0xFFFD,
+        };
+        return cp;
     }
 
     fn handleEscape(self: *Parser, byte: u8) Action {
@@ -357,11 +364,27 @@ pub const Parser = struct {
         // Note: 0x9C (8-bit ST) is NOT handled here because it conflicts
         // with UTF-8 multi-byte sequences (e.g. U+2733 ✳ = E2 9C B3).
         // Only ESC \ (7-bit ST) and BEL are used as terminators.
+        if (self.esc_in_osc) {
+            self.esc_in_osc = false;
+            if (byte == '\\') {
+                // ESC \ = ST — dispatch DCS payload
+                const payload = self.osc_buf[0..self.osc_len];
+                self.osc_len = 0;
+                self.state = .ground;
+                return if (payload.len > 0) Action{ .dcs_dispatch = payload } else .none;
+            } else {
+                // ESC followed by non-backslash — store the ESC and reprocess byte
+                if (self.osc_len < 256) {
+                    self.osc_buf[self.osc_len] = 0x1B;
+                    self.osc_len += 1;
+                }
+                // Fall through to store the current byte
+            }
+        }
         if (byte == 0x1B) {
-            const payload = self.osc_buf[0..self.osc_len];
-            self.osc_len = 0;
-            self.state = .escape;
-            return if (payload.len > 0) Action{ .dcs_dispatch = payload } else .none;
+            // Could be start of ST (ESC \) — wait for next byte
+            self.esc_in_osc = true;
+            return .none;
         } else {
             if (self.osc_len < 256) {
                 self.osc_buf[self.osc_len] = byte;
@@ -808,32 +831,69 @@ fn handleVt52Byte(byte: u8, term: *Term, parser: *Parser, writer_fd: ?std.posix.
 }
 
 fn isWide(cp: u21) bool {
+    // Unicode 15.1 East Asian Width W/F — comprehensive table based on EAW.txt
     // Fast rejection: ASCII, Latin, common symbols (vast majority of chars)
-    if (cp < 0x1100) return false;
+    if (cp < 0x1100) {
+        // Misc wide characters below 0x1100
+        return switch (cp) {
+            0x231A, 0x231B, // Watch, Hourglass
+            0x2329, 0x232A, // Angle brackets
+            0x23E9...0x23F3, // Various clocks/timers
+            0x23F8...0x23FA, // Playback symbols
+            => true,
+            else => false,
+        };
+    }
     if (cp <= 0x115F) return true; // Hangul Jamo
-    // Gap: 0x1160-0x2E7F — various scripts, none wide
+    if (cp < 0x2329) return false;
+    if (cp <= 0x232A) return true; // Angle Brackets (also in switch above but needed for range flow)
     if (cp < 0x2E80) return false;
-    // Main CJK range: 0x2E80-0xA4CF (contiguous wide block)
-    if (cp <= 0xA4CF) return true; // CJK Radicals through Yi
-    // Gap: 0xA4D0-0xA95F
-    if (cp < 0xA960) return false;
-    if (cp <= 0xA97C) return true; // Hangul Jamo Extended-A
-    if (cp < 0xAC00) return false;
-    if (cp <= 0xD7A3) return true; // Hangul Syllables
-    // Gap: 0xD7A4-0xF8FF
-    if (cp < 0xF900) return false;
-    if (cp <= 0xFAFF) return true; // CJK Compatibility Ideographs
-    if (cp < 0xFE10) return false;
-    if (cp <= 0xFE6F) return true; // CJK Compatibility Forms, Small Forms
-    if (cp < 0xFF01) return false;
-    if (cp <= 0xFF60) return true; // Fullwidth Forms
-    if (cp < 0xFFE0) return false;
-    if (cp <= 0xFFE6) return true; // Fullwidth Signs
-    // Supplementary planes
-    if (cp < 0x1F300) return false;
-    if (cp <= 0x1F9FF) return true; // Misc Symbols, Emoticons
-    if (cp < 0x20000) return false;
-    return cp <= 0x3FFFF; // CJK Extension B-G+
+    // CJK Radicals Supplement through Yi Radicals
+    if (cp <= 0x303E) return true; // CJK Radicals, Kangxi, CJK Symbols
+    if (cp >= 0x3041 and cp <= 0x33BF) return true; // Hiragana, Katakana, Bopomofo, Hangul Compat, Kanbun, CJK Strokes
+    if (cp >= 0x33C0 and cp <= 0x33FF) return true; // CJK Compatibility
+    if (cp >= 0x3400 and cp <= 0x4DBF) return true; // CJK Unified Extension A
+    if (cp >= 0x4E00 and cp <= 0xA4CF) return true; // CJK Unified through Yi
+    if (cp >= 0xA960 and cp <= 0xA97C) return true; // Hangul Jamo Extended-A
+    if (cp >= 0xAC00 and cp <= 0xD7A3) return true; // Hangul Syllables
+    if (cp >= 0xF900 and cp <= 0xFAFF) return true; // CJK Compatibility Ideographs
+    if (cp >= 0xFE10 and cp <= 0xFE19) return true; // Vertical Forms
+    if (cp >= 0xFE30 and cp <= 0xFE6F) return true; // CJK Compatibility Forms, Small Form Variants
+    if (cp >= 0xFF01 and cp <= 0xFF60) return true; // Fullwidth Forms
+    if (cp >= 0xFFE0 and cp <= 0xFFE6) return true; // Fullwidth Signs
+    // Supplementary planes — Emoji and CJK extensions
+    return switch (cp) {
+        // Misc Symbols and Pictographs, Emoticons, Transport, etc.
+        0x16FE0...0x16FFF, // Ideographic Symbols
+        0x17000...0x187FF, // Tangut
+        0x18800...0x18AFF, // Tangut Components
+        0x18B00...0x18CFF, // Khitan Small Script
+        0x18D00...0x18D7F, // Tangut Supplement
+        0x1AFF0...0x1AFFF, // Kana Extended-B
+        0x1B000...0x1B0FF, // Kana Supplement
+        0x1B100...0x1B12F, // Kana Extended-A
+        0x1B130...0x1B16F, // Small Kana Extension
+        0x1B170...0x1B2FF, // Nushu
+        0x1F004, 0x1F0CF, // Mahjong, Playing Cards
+        0x1F18E, // Negative Squared AB
+        0x1F191...0x1F19A, // Squared symbols
+        0x1F1E0...0x1F1FF, // Regional Indicators (flags)
+        0x1F200...0x1F2FF, // Enclosed Ideographic Supplement
+        0x1F300...0x1F5FF, // Misc Symbols and Pictographs
+        0x1F600...0x1F64F, // Emoticons
+        0x1F680...0x1F6FF, // Transport and Map Symbols
+        0x1F700...0x1F77F, // Alchemical Symbols (some wide)
+        0x1F780...0x1F7FF, // Geometric Shapes Extended
+        0x1F800...0x1F8FF, // Supplemental Arrows-C
+        0x1F900...0x1F9FF, // Supplemental Symbols and Pictographs
+        0x1FA00...0x1FA6F, // Chess Symbols
+        0x1FA70...0x1FAFF, // Symbols and Pictographs Extended-A
+        0x1FB00...0x1FBFF, // Symbols for Legacy Computing
+        0x20000...0x2FFFF, // CJK Extensions B-G, Compatibility Supplement
+        0x30000...0x3FFFF, // CJK Extension H+
+        => true,
+        else => false,
+    };
 }
 
 fn handlePrint(cp: u21, term: *Term) void {

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -545,6 +545,7 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                     const b1 = data[i + 1];
                     if (b1 & 0xC0 != 0x80) break;
                     cp = (@as(u21, first & 0x1F) << 6) | @as(u21, b1 & 0x3F);
+                    if (cp < 0x80) cp = 0xFFFD; // reject overlong
                     seq_len = 2;
                 } else if (first < 0xF0) {
                     if (i + 2 >= data.len) break;
@@ -552,15 +553,21 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                     const b2 = data[i + 2];
                     if (b1 & 0xC0 != 0x80 or b2 & 0xC0 != 0x80) break;
                     cp = (@as(u21, first & 0x0F) << 12) | (@as(u21, b1 & 0x3F) << 6) | @as(u21, b2 & 0x3F);
+                    if (cp < 0x800 or (cp >= 0xD800 and cp <= 0xDFFF)) cp = 0xFFFD; // reject overlong/surrogate
                     seq_len = 3;
-                } else {
+                } else if (first < 0xF5) {
                     if (i + 3 >= data.len) break;
                     const b1 = data[i + 1];
                     const b2 = data[i + 2];
                     const b3 = data[i + 3];
                     if (b1 & 0xC0 != 0x80 or b2 & 0xC0 != 0x80 or b3 & 0xC0 != 0x80) break;
                     cp = (@as(u21, first & 0x07) << 18) | (@as(u21, b1 & 0x3F) << 12) | (@as(u21, b2 & 0x3F) << 6) | @as(u21, b3 & 0x3F);
+                    if (cp < 0x10000 or cp > 0x10FFFF) cp = 0xFFFD; // reject overlong/>U+10FFFF
                     seq_len = 4;
+                } else {
+                    // 0xF5..0xFD: invalid lead byte, skip
+                    i += 1;
+                    continue;
                 }
                 // Wide chars need handlePrint for dummy cell logic
                 if (isWide(cp)) {


### PR DESCRIPTION
## **User description**
## Summary
- Fix UAF in `term.resize()` — allocate all alt-screen buffers before freeing old ones
- Fix PTY write truncation — increase buffer 4KB→64KB, flush before append when full
- Fix `isWide()` table — add missing Unicode 15.1 EAW W/F ranges (fixes wide chars half-displayed)
- Fix XIM init order — `ensureKeyboardInit()` before XIM filter for first key press
- Fix DCS parser — require ESC+`\` (ST) to terminate, not bare ESC
- Fix UTF-8 decoder — reject overlong, surrogates, >U+10FFFF
- Fix DECBKM — send BS (0x08) when decbkm=true
- Fix IME cursor i16 overflow — clamp to maxInt(i16)
- Fix XKB init leak — unref context/keymap on early return

## Test plan
- [x] `zig build` passes
- [x] `zig build test` passes
- [ ] Verify wide characters (emoji, CJK) display correctly without half-cutoff
- [ ] Verify IME input works with cursor following
- [ ] Verify large paste doesn't lose data
- [ ] Verify Backspace behavior with DECBKM on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix input handling, terminal resizing, and display accuracy**

### What Changed
- Large pastes and IME commits are less likely to be cut off because terminal writes now keep a much larger outgoing buffer and flush pending data before dropping anything.
- Backspace now follows the terminal’s configured delete/backspace mode, and arrow key handling now respects that setting too.
- Wide characters such as emoji and CJK symbols are recognized more completely, reducing half-width or misaligned display.
- Resizing the terminal no longer frees old alternate-screen data before new space is ready, avoiding crashes when memory is tight.
- IME cursor placement now stays within range on very large windows, and first key presses are handled reliably after keyboard setup.
- Invalid UTF-8 and DCS sequences are rejected or terminated correctly, preventing corrupted input from being accepted.
- X keyboard setup now cleans up properly if it cannot finish initializing.

### Impact
`✅ Fewer cut-off pastes and IME commits`
`✅ Correct Backspace behavior in more terminal apps`
`✅ Fewer misaligned wide characters`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**バグ修正**
- UTF-8 デコード検証を強化し、無効なシーケンスを正しく処理
- オーバーフロー防止およびリソースリーク修正
- DCS パーサー（ESC \ シーケンス）の処理改善
- Unicode 幅文字検出の精度を向上

**パフォーマンス向上**
- PTY 書き込みバッファを 4KB から 64KB に拡張、より大きなデータを効率的に処理
- ターミナルリサイズ時のメモリ管理を最適化

**機能改善**
- Backspace キー設定（DECBKM モード）に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->