### PR TITLE
Fix wide char right-half display bugs in UTF-8 fast path

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -808,6 +808,28 @@ pub fn main() !void {
             backend.markDirtyRows(0, backend.getHeight() - 1);
         }
 
+        // Pre-pass: propagate dirty from wide_dummy to its wide cell neighbor.
+        // The render loop skips wide_dummy cells (the wide cell draws both halves),
+        // so a dirty dummy with a non-dirty wide cell would leave stale pixels.
+        if (!all_dirty) {
+            var py: u32 = 0;
+            while (py < term.rows) : (py += 1) {
+                if (!term.isRowDirty(py)) continue;
+                const p_phys = term.row_map[py];
+                const p_base = @as(usize, p_phys) * @as(usize, term.cols);
+                const p_cells = term.cells[p_base..][0..term.cols];
+                const p_dirty_base = @as(usize, py) * @as(usize, term.cols);
+                var px: u32 = 1;
+                while (px < term.cols) : (px += 1) {
+                    if (term.dirty.isSet(p_dirty_base + px) and p_cells[px].attrs.wide_dummy and
+                        !term.dirty.isSet(p_dirty_base + px - 1))
+                    {
+                        term.dirty.set(p_dirty_base + px - 1);
+                    }
+                }
+            }
+        }
+
         var y: u32 = 0;
         while (y < term.rows) : (y += 1) {
             if (!all_dirty and !term.isRowDirty(y)) continue;

--- a/src/main.zig
+++ b/src/main.zig
@@ -761,7 +761,10 @@ pub fn main() !void {
             var extra_total: usize = 0;
             while (extra_total < config.pty_buf_size * 4) {
                 const extra = pty.read(&pty_buf) catch break;
-                if (extra == 0) { running = false; break; }
+                if (extra == 0) {
+                    running = false;
+                    break;
+                }
                 bytes_since_render += extra;
                 extra_total += extra;
                 vt.feedBulk(&parser, pty_buf[0..extra], &term, pty.master_fd);
@@ -806,28 +809,6 @@ pub fn main() !void {
             const pixel_buf: [*][4]u8 = @ptrCast(buf.ptr);
             @memset(pixel_buf[0..total_pixels], bg_packed);
             backend.markDirtyRows(0, backend.getHeight() - 1);
-        }
-
-        // Pre-pass: propagate dirty from wide_dummy to its wide cell neighbor.
-        // The render loop skips wide_dummy cells (the wide cell draws both halves),
-        // so a dirty dummy with a non-dirty wide cell would leave stale pixels.
-        if (!all_dirty) {
-            var py: u32 = 0;
-            while (py < term.rows) : (py += 1) {
-                if (!term.isRowDirty(py)) continue;
-                const p_phys = term.row_map[py];
-                const p_base = @as(usize, p_phys) * @as(usize, term.cols);
-                const p_cells = term.cells[p_base..][0..term.cols];
-                const p_dirty_base = @as(usize, py) * @as(usize, term.cols);
-                var px: u32 = 1;
-                while (px < term.cols) : (px += 1) {
-                    if (term.dirty.isSet(p_dirty_base + px) and p_cells[px].attrs.wide_dummy and
-                        !term.dirty.isSet(p_dirty_base + px - 1))
-                    {
-                        term.dirty.set(p_dirty_base + px - 1);
-                    }
-                }
-            }
         }
 
         var y: u32 = 0;

--- a/src/term.zig
+++ b/src/term.zig
@@ -237,6 +237,16 @@ pub const Term = struct {
         if (x >= self.cols or y >= self.rows) return;
         self.dirty.set(self.dirtyIndex(x, y, self.cols));
         self.dirty_flag = true;
+        // Wide-aware propagation: if marking a wide_dummy (right half),
+        // also mark its parent wide cell (left half) so the render loop
+        // redraws both halves.
+        if (x > 0) {
+            const phys_row = self.row_map[y];
+            const phys_idx = @as(usize, phys_row) * @as(usize, self.cols) + x;
+            if (self.cells[phys_idx].attrs.wide_dummy) {
+                self.dirty.set(self.dirtyIndex(x - 1, y, self.cols));
+            }
+        }
     }
 
     pub fn hasDirty(self: *const Self) bool {

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -516,10 +516,28 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                 // Inline control character handling — stay in fast path loop
                 if (i < data.len) {
                     switch (data[i]) {
-                        0x0A, 0x0B, 0x0C => { term.wrap_next = false; term.insertNewline(); i += 1; continue; },
-                        0x0D => { term.carriageReturn(); i += 1; continue; },
-                        0x08 => { term.wrap_next = false; if (term.cursor_x > 0) term.cursor_x -= 1; i += 1; continue; },
-                        0x09 => { term.tputtab(1); i += 1; continue; },
+                        0x0A, 0x0B, 0x0C => {
+                            term.wrap_next = false;
+                            term.insertNewline();
+                            i += 1;
+                            continue;
+                        },
+                        0x0D => {
+                            term.carriageReturn();
+                            i += 1;
+                            continue;
+                        },
+                        0x08 => {
+                            term.wrap_next = false;
+                            if (term.cursor_x > 0) term.cursor_x -= 1;
+                            i += 1;
+                            continue;
+                        },
+                        0x09 => {
+                            term.tputtab(1);
+                            i += 1;
+                            continue;
+                        },
                         else => {},
                     }
                 }
@@ -599,6 +617,7 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                     term.cells[wide_phys] = term.blankCell();
                     term.fg_rgb[wide_phys] = null;
                     term.bg_rgb[wide_phys] = term.current_bg_rgb;
+                    if (term.current_bg_rgb != null) term.has_truecolor_cells = true;
                     term.markDirty(term.cursor_x - 1, term.cursor_y);
                 } else if (term.cells[phys_idx].attrs.wide and term.cursor_x + 1 < cols) {
                     // Overwriting a wide cell (left half): clear the dummy to its right
@@ -606,6 +625,7 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                     term.cells[dummy_phys] = term.blankCell();
                     term.fg_rgb[dummy_phys] = null;
                     term.bg_rgb[dummy_phys] = term.current_bg_rgb;
+                    if (term.current_bg_rgb != null) term.has_truecolor_cells = true;
                     term.markDirty(term.cursor_x + 1, term.cursor_y);
                 }
                 term.cells[phys_idx] = .{
@@ -813,25 +833,46 @@ fn handleVt52Byte(byte: u8, term: *Term, parser: *Parser, writer_fd: ?std.posix.
     if (parser.state == .escape) {
         parser.state = .ground;
         switch (byte) {
-            'A' => { term.wrap_next = false; if (term.cursor_y > 0) term.cursor_y -= 1; },
-            'B' => { term.wrap_next = false; if (term.cursor_y < term.rows - 1) term.cursor_y += 1; },
-            'C' => { term.wrap_next = false; if (term.cursor_x < term.cols - 1) term.cursor_x += 1; },
-            'D' => { term.wrap_next = false; if (term.cursor_x > 0) term.cursor_x -= 1; },
+            'A' => {
+                term.wrap_next = false;
+                if (term.cursor_y > 0) term.cursor_y -= 1;
+            },
+            'B' => {
+                term.wrap_next = false;
+                if (term.cursor_y < term.rows - 1) term.cursor_y += 1;
+            },
+            'C' => {
+                term.wrap_next = false;
+                if (term.cursor_x < term.cols - 1) term.cursor_x += 1;
+            },
+            'D' => {
+                term.wrap_next = false;
+                if (term.cursor_x > 0) term.cursor_x -= 1;
+            },
             'F' => term.charsets[0] = .dec_graphics,
             'G' => term.charsets[0] = .us_ascii,
-            'H' => { term.cursor_x = 0; term.cursor_y = 0; term.wrap_next = false; },
+            'H' => {
+                term.cursor_x = 0;
+                term.cursor_y = 0;
+                term.wrap_next = false;
+            },
             'I' => { // Reverse LF
                 term.wrap_next = false;
-                if (term.cursor_y == term.scroll_top) term.scrollDown(1)
-                else if (term.cursor_y > 0) term.cursor_y -= 1;
+                if (term.cursor_y == term.scroll_top) term.scrollDown(1) else if (term.cursor_y > 0) term.cursor_y -= 1;
             },
             'J' => term.eraseDisplay(0),
             'K' => term.eraseLine(0),
-            'Y' => { parser.utf8_buf[0] = 'Y'; return; }, // Begin cursor addressing
+            'Y' => {
+                parser.utf8_buf[0] = 'Y';
+                return;
+            }, // Begin cursor addressing
             'Z' => { // Identify
                 if (writer_fd) |fd| _ = std.posix.write(fd, "\x1b/Z") catch {};
             },
-            '<' => { term.vt52_mode = false; parser.utf8_buf[0] = 0; }, // Exit VT52 → VT100
+            '<' => {
+                term.vt52_mode = false;
+                parser.utf8_buf[0] = 0;
+            }, // Exit VT52 → VT100
             '=' => term.deckpam = true,
             '>' => term.deckpam = false,
             else => {},
@@ -885,7 +926,8 @@ fn isWide(cp: u21) bool {
         0x1B100...0x1B12F, // Kana Extended-A
         0x1B130...0x1B16F, // Small Kana Extension
         0x1B170...0x1B2FF, // Nushu
-        0x1F004, 0x1F0CF, // Mahjong, Playing Cards
+        0x1F004,
+        0x1F0CF, // Mahjong, Playing Cards
         0x1F18E, // Negative Squared AB
         0x1F191...0x1F19A, // Squared symbols
         0x1F1E0...0x1F1FF, // Regional Indicators (flags)
@@ -1488,7 +1530,9 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
             // Left/right margin mode
             69 => {},
             // Silently ignored DEC modes
-            2 => { if (!set) term.vt52_mode = true; }, // DECANM reset → VT52 mode
+            2 => {
+                if (!set) term.vt52_mode = true;
+            }, // DECANM reset → VT52 mode
             0, 3, 4, 5, 8, 12, 18, 19, 38, 42, 45, 66, 2031 => {},
             else => {
                 std.log.warn("unhandled DEC mode: {d} set={}", .{ p[i], set });

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -594,7 +594,19 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                 const phys_idx = @as(usize, phys_row) * @as(usize, cols) + term.cursor_x;
                 // Fix wide char boundary if overwriting
                 if (term.cells[phys_idx].attrs.wide_dummy and term.cursor_x > 0) {
-                    term.cells[phys_idx - 1] = Cell{};
+                    // Overwriting a dummy (right half): clear the wide cell to its left
+                    const wide_phys = phys_idx - 1;
+                    term.cells[wide_phys] = term.blankCell();
+                    term.fg_rgb[wide_phys] = null;
+                    term.bg_rgb[wide_phys] = term.current_bg_rgb;
+                    term.markDirty(term.cursor_x - 1, term.cursor_y);
+                } else if (term.cells[phys_idx].attrs.wide and term.cursor_x + 1 < cols) {
+                    // Overwriting a wide cell (left half): clear the dummy to its right
+                    const dummy_phys = phys_idx + 1;
+                    term.cells[dummy_phys] = term.blankCell();
+                    term.fg_rgb[dummy_phys] = null;
+                    term.bg_rgb[dummy_phys] = term.current_bg_rgb;
+                    term.markDirty(term.cursor_x + 1, term.cursor_y);
                 }
                 term.cells[phys_idx] = .{
                     .char = cp,


### PR DESCRIPTION
## **User description**
## Summary
- **UTF-8 fast path wide_dummy overwrite**: Fixed incomplete boundary cleanup — now uses `blankCell()`, clears TrueColor arrays, and marks dirty (matching ASCII fast path behavior)
- **UTF-8 fast path wide cell overwrite**: Added missing dummy cell cleanup when a narrow char overwrites a wide cell's left half (was completely absent, unlike ASCII fast path)
- **Render loop defense-in-depth**: Added pre-pass to propagate dirty bits from `wide_dummy` cells to their wide cell neighbor, preventing stale pixels from any dirty-tracking gaps

## Root Cause
The UTF-8 medium fast path (`vt.zig:596-598`) had two gaps compared to the ASCII fast path (`vt.zig:471-490`):
1. Clearing a wide cell when overwriting its dummy used `Cell{}` without marking dirty or cleaning TrueColor
2. No check existed for overwriting a `wide=true` cell (orphaned dummy remained)

Combined with the render loop skipping both non-dirty wide cells and `wide_dummy` cells, this caused the right half of CJK characters to intermittently show stale/blank pixels.

## Test plan
- [x] `zig build` compiles cleanly
- [x] `zig build test` passes all tests
- [ ] Manual: display CJK text, verify no half-character artifacts
- [ ] Manual: rapid scrolling with mixed ASCII/CJK content
- [ ] Manual: cursor movement over wide characters in vim/less

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix stale or broken right halves of wide characters in terminal output**

### What Changed
- Overwriting the right half of a wide character now clears the full character cell on the left, instead of leaving stale content behind.
- Overwriting the left half of a wide character now also clears the matching cell on the right, so the full wide character is removed cleanly.
- If a wide-character half is marked dirty, the paired cell is now redrawn too, preventing blank or half-rendered CJK characters.

### Impact
`✅ Fewer broken wide-character displays`
`✅ Cleaner overwrites in CJK text`
`✅ Reduced stale character artifacts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ワイド文字（全角文字など）のレンダリングの問題を修正し、古いピクセルが残ったり不正な表示になる問題に対応しました
* テキスト上書き時のワイド文字処理を改善し、ワイド文字ペアの両側が正確に更新されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->