### PR TITLE
Add OSC 52 clipboard, styled underlines, and OSC 8 hyperlinks

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -312,7 +312,16 @@ fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend)
     };
 
     return switch (signo) {
-        SIG_CHLD, SIG_TERM, SIG_INT, SIG_HUP => false,
+        SIG_CHLD => blk: {
+            // Reap zombie children (clipboard helpers, etc.) without exiting.
+            // PTY child death is detected by read() returning 0 in the event loop.
+            while (true) {
+                const result = std.posix.waitpid(-1, linux.W.NOHANG);
+                if (result.pid <= 0) break; // no more children to reap
+            }
+            break :blk true;
+        },
+        SIG_TERM, SIG_INT, SIG_HUP => false,
         SIG_USR1 => blk: {
             backend.releaseVt();
             break :blk true;
@@ -330,41 +339,40 @@ fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend)
 /// Dispatch clipboard copy via external tool (xclip for X11, wl-copy for Wayland).
 /// Non-blocking: forks a child process and writes data to its stdin.
 fn dispatchClipboardCopy(data: []const u8) void {
-    if (data.len == 0) return;
-
-    const tool: []const []const u8 = switch (config.backend) {
-        .x11 => &.{ "xclip", "-selection", "clipboard" },
-        .wayland => &.{"wl-copy"},
+    const argv: [*:null]const ?[*:0]const u8 = switch (config.backend) {
+        .x11 => &[_:null]?[*:0]const u8{ "xclip", "-selection", "clipboard" },
+        .wayland => &[_:null]?[*:0]const u8{"wl-copy"},
         else => return,
     };
 
-    const pipe = std.posix.pipe2(.{ .CLOEXEC = true }) catch return;
+    const pipe_fds = std.posix.pipe() catch return;
     const pid = std.posix.fork() catch {
-        std.posix.close(pipe[0]);
-        std.posix.close(pipe[1]);
+        std.posix.close(pipe_fds[0]);
+        std.posix.close(pipe_fds[1]);
         return;
     };
 
     if (pid == 0) {
         // Child: redirect stdin from pipe read end
-        std.posix.dup2(pipe[0], 0) catch std.posix.exit(1);
-        std.posix.close(pipe[0]);
-        std.posix.close(pipe[1]);
+        std.posix.dup2(pipe_fds[0], 0) catch std.posix.exit(1);
+        std.posix.close(pipe_fds[0]);
+        std.posix.close(pipe_fds[1]);
 
         const err = std.posix.execvpeZ(
-            tool[0].ptr,
-            @ptrCast(tool.ptr),
+            argv[0].?,
+            argv,
             @ptrCast(std.c.environ),
         );
         _ = err;
         std.posix.exit(1);
     }
 
-    // Parent: write data to pipe write end, close both
-    std.posix.close(pipe[0]);
-    _ = std.posix.write(pipe[1], data) catch {};
-    std.posix.close(pipe[1]);
-    // Don't waitpid — let child be reaped by SIGCHLD handler or init
+    // Parent: write data to pipe write end, close read end immediately
+    std.posix.close(pipe_fds[0]);
+    if (data.len > 0) {
+        _ = std.posix.write(pipe_fds[1], data) catch {};
+    }
+    std.posix.close(pipe_fds[1]); // EOF signals end of data to child
 }
 
 fn handleBackendEvent(

--- a/src/main.zig
+++ b/src/main.zig
@@ -315,8 +315,9 @@ fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend)
         SIG_CHLD => blk: {
             // Reap zombie children (clipboard helpers, etc.) without exiting.
             // PTY child death is detected by read() returning 0 in the event loop.
+            const WNOHANG: u32 = if (is_linux) linux.W.NOHANG else 1; // WNOHANG=1 on macOS/BSD too
             while (true) {
-                const result = std.posix.waitpid(-1, linux.W.NOHANG);
+                const result = std.posix.waitpid(-1, WNOHANG);
                 if (result.pid <= 0) break; // no more children to reap
             }
             break :blk true;
@@ -345,6 +346,13 @@ fn dispatchClipboardCopy(data: []const u8) void {
         else => return,
     };
 
+    // Block SIGPIPE to prevent write() from killing us if child dies early
+    if (is_linux) {
+        var mask = linux.sigemptyset();
+        linux.sigaddset(&mask, linux.SIG.PIPE);
+        _ = linux.sigprocmask(linux.SIG.BLOCK, &mask, null);
+    }
+
     const pipe_fds = std.posix.pipe() catch return;
     const pid = std.posix.fork() catch {
         std.posix.close(pipe_fds[0]);
@@ -358,12 +366,11 @@ fn dispatchClipboardCopy(data: []const u8) void {
         std.posix.close(pipe_fds[0]);
         std.posix.close(pipe_fds[1]);
 
-        const err = std.posix.execvpeZ(
+        _ = std.posix.execvpeZ(
             argv[0].?,
             argv,
             @ptrCast(std.c.environ),
-        );
-        _ = err;
+        ) catch {};
         std.posix.exit(1);
     }
 
@@ -373,6 +380,13 @@ fn dispatchClipboardCopy(data: []const u8) void {
         _ = std.posix.write(pipe_fds[1], data) catch {};
     }
     std.posix.close(pipe_fds[1]); // EOF signals end of data to child
+
+    // Unblock SIGPIPE
+    if (is_linux) {
+        var mask = linux.sigemptyset();
+        linux.sigaddset(&mask, linux.SIG.PIPE);
+        _ = linux.sigprocmask(linux.SIG.UNBLOCK, &mask, null);
+    }
 }
 
 fn handleBackendEvent(

--- a/src/main.zig
+++ b/src/main.zig
@@ -327,6 +327,46 @@ fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend)
 
 /// Handle a single backend event (key, text, paste, resize, etc.).
 /// Returns false if the event loop should stop (close event or write failure).
+/// Dispatch clipboard copy via external tool (xclip for X11, wl-copy for Wayland).
+/// Non-blocking: forks a child process and writes data to its stdin.
+fn dispatchClipboardCopy(data: []const u8) void {
+    if (data.len == 0) return;
+
+    const tool: []const []const u8 = switch (config.backend) {
+        .x11 => &.{ "xclip", "-selection", "clipboard" },
+        .wayland => &.{"wl-copy"},
+        else => return,
+    };
+
+    const pipe = std.posix.pipe2(.{ .CLOEXEC = true }) catch return;
+    const pid = std.posix.fork() catch {
+        std.posix.close(pipe[0]);
+        std.posix.close(pipe[1]);
+        return;
+    };
+
+    if (pid == 0) {
+        // Child: redirect stdin from pipe read end
+        std.posix.dup2(pipe[0], 0) catch std.posix.exit(1);
+        std.posix.close(pipe[0]);
+        std.posix.close(pipe[1]);
+
+        const err = std.posix.execvpeZ(
+            tool[0].ptr,
+            @ptrCast(tool.ptr),
+            @ptrCast(std.c.environ),
+        );
+        _ = err;
+        std.posix.exit(1);
+    }
+
+    // Parent: write data to pipe write end, close both
+    std.posix.close(pipe[0]);
+    _ = std.posix.write(pipe[1], data) catch {};
+    std.posix.close(pipe[1]);
+    // Don't waitpid — let child be reaped by SIGCHLD handler or init
+}
+
 fn handleBackendEvent(
     event: *const BackendEvent,
     term: *Term,
@@ -772,6 +812,12 @@ pub fn main() !void {
             }
         }
 
+        // OSC 52: copy to system clipboard via external tool
+        if (term.osc52_pending) {
+            term.osc52_pending = false;
+            dispatchClipboardCopy(term.osc52_buf[0..term.osc52_len]);
+        }
+
         // Mark old cursor position dirty if cursor moved
         if (prev_cursor_x != term.cursor_x or prev_cursor_y != term.cursor_y) {
             term.markDirty(prev_cursor_x, prev_cursor_y);
@@ -835,6 +881,7 @@ pub fn main() !void {
             const row_cells = term.cells[row_base..][0..term.cols];
             const row_fg = term.fg_rgb[row_base..][0..term.cols];
             const row_bg = term.bg_rgb[row_base..][0..term.cols];
+            const row_ul = term.ul_color_rgb[row_base..][0..term.cols];
             const dirty_row_base = @as(usize, y) * @as(usize, term.cols);
 
             var x: u32 = 0;
@@ -846,6 +893,7 @@ pub fn main() !void {
 
                 var fg_rgb = row_fg[x];
                 var bg_rgb = row_bg[x];
+                const ul_rgb = row_ul[x];
                 const glyph = if (cell.char == ' ' or cell.char == 0) null else FontType.getGlyph(cell.char);
                 const is_cursor = (x == term.cursor_x and y == term.cursor_y and term.cursor_visible and cursor_visible_blink);
 
@@ -866,15 +914,15 @@ pub fn main() !void {
                 const skip_bg = all_dirty and (render_cell.bg == config.default_bg) and (bg_rgb == null) and !render_cell.attrs.reverse;
                 if (skip_bg) {
                     if (cell.attrs.wide) {
-                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, glyph, config.font_width, config.font_height, .bgra32, true, config.scale, true);
+                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, ul_rgb, glyph, config.font_width, config.font_height, .bgra32, true, config.scale, true);
                     } else {
-                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, glyph, config.font_width, config.font_height, .bgra32, false, config.scale, true);
+                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, ul_rgb, glyph, config.font_width, config.font_height, .bgra32, false, config.scale, true);
                     }
                 } else {
                     if (cell.attrs.wide) {
-                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, glyph, config.font_width, config.font_height, .bgra32, true, config.scale, false);
+                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, ul_rgb, glyph, config.font_width, config.font_height, .bgra32, true, config.scale, false);
                     } else {
-                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, glyph, config.font_width, config.font_height, .bgra32, false, config.scale, false);
+                        render.renderCell(buf, stride, x, y, render_cell, fg_rgb, bg_rgb, ul_rgb, glyph, config.font_width, config.font_height, .bgra32, false, config.scale, false);
                     }
                 }
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -243,10 +243,20 @@ pub fn renderCell(
         const ul_color = if (ul_rgb_override) |rgb| Color{ .r = rgb[0], .g = rgb[1], .b = rgb[2] } else fg_color;
         const ul_start = (font_h - 2) * scale;
 
+        // Multi-line styles need earlier start to stay within cell bounds
+        const cell_bottom = font_h * scale;
         switch (ul_style) {
             1 => drawUnderlineSingle(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
-            2 => drawUnderlineDouble(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
-            3 => drawUnderlineCurly(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+            2 => {
+                // Double: two lines separated by scale pixels, both within cell
+                const dbl_start = if (ul_start + 2 * scale >= cell_bottom) ul_start -| (2 * scale) else ul_start;
+                drawUnderlineDouble(buffer, stride, px_x, px_y, dbl_start, scaled_w, ul_color, max_offset, pixel_format, scale);
+            },
+            3 => {
+                // Curly: 3-pixel wave, shift up to stay in cell
+                const curly_start = if (ul_start + 3 * scale > cell_bottom) ul_start -| (3 * scale) else ul_start;
+                drawUnderlineCurly(buffer, stride, px_x, px_y, curly_start, scaled_w, ul_color, max_offset, pixel_format, scale);
+            },
             4 => drawUnderlineDotted(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
             5 => drawUnderlineDashed(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
             else => drawUnderlineSingle(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),

--- a/src/render.zig
+++ b/src/render.zig
@@ -94,6 +94,7 @@ pub fn renderCell(
     cell: Cell,
     fg_rgb_override: ?[3]u8,
     bg_rgb_override: ?[3]u8,
+    ul_rgb_override: ?[3]u8,
     glyph: ?GlyphView,
     comptime font_w: u32,
     comptime font_h: u32,
@@ -235,29 +236,172 @@ pub fn renderCell(
         }
     }
 
-    // 8. Underline: at (font_h - 2) * scale with scale-pixel thickness
-    if (cell.attrs.underline) {
+    // 8. Underline (styled): at (font_h - 2) * scale
+    const ul_style = cell.attrs.underline_style;
+    if (ul_style != 0) {
+        // Underline color: use override if present, otherwise fg_color
+        const ul_color = if (ul_rgb_override) |rgb| Color{ .r = rgb[0], .g = rgb[1], .b = rgb[2] } else fg_color;
         const ul_start = (font_h - 2) * scale;
-        if (pixel_format == .bgra32) {
-            const fg_packed = [4]u8{ fg_color.b, fg_color.g, fg_color.r, 0xFF };
-            for (0..scale) |s| {
-                const row_offset = (px_y + ul_start + @as(u32, @intCast(s))) * stride + px_x * bpp;
-                if (row_offset + scaled_w * 4 <= max_offset) {
-                    const pixels: [*][4]u8 = @ptrCast(buffer.ptr + row_offset);
-                    @memset(pixels[0..scaled_w], fg_packed);
-                }
+
+        switch (ul_style) {
+            1 => drawUnderlineSingle(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+            2 => drawUnderlineDouble(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+            3 => drawUnderlineCurly(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+            4 => drawUnderlineDotted(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+            5 => drawUnderlineDashed(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+            else => drawUnderlineSingle(buffer, stride, px_x, px_y, ul_start, scaled_w, ul_color, max_offset, pixel_format, scale),
+        }
+    }
+}
+
+// --- Underline style helpers ---
+
+fn drawUnderlineSingle(
+    buffer: []u8,
+    stride: u32,
+    px_x: u32,
+    px_y: u32,
+    ul_start: u32,
+    scaled_w: u32,
+    color: Color,
+    max_offset: usize,
+    comptime pixel_format: PixelFormat,
+    comptime scale: u32,
+) void {
+    const bpp = comptime bppFor(pixel_format);
+    if (pixel_format == .bgra32) {
+        const bgra = [4]u8{ color.b, color.g, color.r, 0xFF };
+        for (0..scale) |s| {
+            const row_offset = (px_y + ul_start + @as(u32, @intCast(s))) * stride + px_x * bpp;
+            if (row_offset + scaled_w * 4 <= max_offset) {
+                const pixels: [*][4]u8 = @ptrCast(buffer.ptr + row_offset);
+                @memset(pixels[0..scaled_w], bgra);
             }
-        } else {
-            for (0..scale) |s| {
-                const row_offset = (px_y + ul_start + @as(u32, @intCast(s))) * stride + px_x * bpp;
-                for (0..scaled_w) |col| {
-                    const offset = row_offset + @as(u32, @intCast(col)) * bpp;
-                    if (offset + bpp > max_offset) continue;
-                    writePixel(buffer, offset, fg_color, pixel_format);
-                }
+        }
+    } else {
+        for (0..scale) |s| {
+            const row_offset = (px_y + ul_start + @as(u32, @intCast(s))) * stride + px_x * bpp;
+            for (0..scaled_w) |col| {
+                const offset = row_offset + @as(u32, @intCast(col)) * bpp;
+                if (offset + bpp > max_offset) continue;
+                writePixel(buffer, offset, color, pixel_format);
             }
         }
     }
+}
+
+fn drawUnderlineDouble(
+    buffer: []u8,
+    stride: u32,
+    px_x: u32,
+    px_y: u32,
+    ul_start: u32,
+    scaled_w: u32,
+    color: Color,
+    max_offset: usize,
+    comptime pixel_format: PixelFormat,
+    comptime scale: u32,
+) void {
+    // Two lines: one at ul_start, one at ul_start + 2*scale
+    drawUnderlineSingle(buffer, stride, px_x, px_y, ul_start, scaled_w, color, max_offset, pixel_format, scale);
+    const second_start = ul_start + 2 * scale;
+    drawUnderlineSingle(buffer, stride, px_x, px_y, second_start, scaled_w, color, max_offset, pixel_format, scale);
+}
+
+fn drawUnderlineCurly(
+    buffer: []u8,
+    stride: u32,
+    px_x: u32,
+    px_y: u32,
+    ul_start: u32,
+    scaled_w: u32,
+    color: Color,
+    max_offset: usize,
+    comptime pixel_format: PixelFormat,
+    comptime scale: u32,
+) void {
+    // Sine-like wave: 3 pixel height, period = scaled_w
+    const bpp = comptime bppFor(pixel_format);
+    const height: u32 = 3 * scale;
+    for (0..scaled_w) |col_usize| {
+        const col: u32 = @intCast(col_usize);
+        // Simple wave pattern: 0,1,2,1,0,1,2,1,... (period 4)
+        const phase = col / scale % 4;
+        const dy: u32 = switch (phase) {
+            0 => 0,
+            1 => 1 * scale,
+            2 => 2 * scale,
+            3 => 1 * scale,
+            else => 0,
+        };
+        _ = height;
+        for (0..scale) |s| {
+            const row_offset = (px_y + ul_start + dy + @as(u32, @intCast(s))) * stride + (px_x + col) * bpp;
+            if (row_offset + bpp <= max_offset) {
+                writePixel(buffer, row_offset, color, pixel_format);
+            }
+        }
+    }
+}
+
+fn drawUnderlineDotted(
+    buffer: []u8,
+    stride: u32,
+    px_x: u32,
+    px_y: u32,
+    ul_start: u32,
+    scaled_w: u32,
+    color: Color,
+    max_offset: usize,
+    comptime pixel_format: PixelFormat,
+    comptime scale: u32,
+) void {
+    // Every other pixel
+    const bpp = comptime bppFor(pixel_format);
+    for (0..scaled_w) |col_usize| {
+        const col: u32 = @intCast(col_usize);
+        if ((col / scale) % 2 != 0) continue;
+        for (0..scale) |s| {
+            const row_offset = (px_y + ul_start + @as(u32, @intCast(s))) * stride + (px_x + col) * bpp;
+            if (row_offset + bpp <= max_offset) {
+                writePixel(buffer, row_offset, color, pixel_format);
+            }
+        }
+    }
+}
+
+fn drawUnderlineDashed(
+    buffer: []u8,
+    stride: u32,
+    px_x: u32,
+    px_y: u32,
+    ul_start: u32,
+    scaled_w: u32,
+    color: Color,
+    max_offset: usize,
+    comptime pixel_format: PixelFormat,
+    comptime scale: u32,
+) void {
+    // 3 on, 1 off pattern
+    const bpp = comptime bppFor(pixel_format);
+    for (0..scaled_w) |col_usize| {
+        const col: u32 = @intCast(col_usize);
+        if ((col / scale) % 4 == 3) continue; // gap
+        for (0..scale) |s| {
+            const row_offset = (px_y + ul_start + @as(u32, @intCast(s))) * stride + (px_x + col) * bpp;
+            if (row_offset + bpp <= max_offset) {
+                writePixel(buffer, row_offset, color, pixel_format);
+            }
+        }
+    }
+}
+
+fn bppFor(comptime pixel_format: PixelFormat) u32 {
+    return switch (pixel_format) {
+        .bgra32 => 4,
+        .rgb24 => 3,
+        .rgb565 => 2,
+    };
 }
 
 // --- Tests ---
@@ -295,7 +439,7 @@ test "Render: renderCell writes pixels to buffer" {
     const bitmap = [_]u8{ 0x00, 0x00, 0x18, 0x24, 0x42, 0x42, 0x42, 0x7E, 0x42, 0x42, 0x42, 0x42, 0x00, 0x00, 0x00, 0x00 };
     const glyph = GlyphView{ .codepoint = 'A', .width = 8, .height = 16, .bitmap = &bitmap };
 
-    renderCell(&buffer, stride, 0, 0, .{ .char = 'A', .fg = 7, .bg = 0 }, null, null, glyph, w, h, .bgra32, false, 1, false);
+    renderCell(&buffer, stride, 0, 0, .{ .char = 'A', .fg = 7, .bg = 0 }, null, null, null, glyph, w, h, .bgra32, false, 1, false);
 
     // Row 2 (0x18 = bits 3,4) should have white pixels at columns 3 and 4
     const row2_start = 2 * stride;
@@ -323,7 +467,7 @@ test "Render: renderCell scale=2 writes 2x2 pixel blocks" {
     const bitmap = [_]u8{ 0x00, 0x00, 0x18, 0x24, 0x42, 0x42, 0x42, 0x7E, 0x42, 0x42, 0x42, 0x42, 0x00, 0x00, 0x00, 0x00 };
     const glyph = GlyphView{ .codepoint = 'A', .width = 8, .height = 16, .bitmap = &bitmap };
 
-    renderCell(&buffer, stride, 0, 0, .{ .char = 'A', .fg = 7, .bg = 0 }, null, null, glyph, w, h, .bgra32, false, scale, false);
+    renderCell(&buffer, stride, 0, 0, .{ .char = 'A', .fg = 7, .bg = 0 }, null, null, null, glyph, w, h, .bgra32, false, scale, false);
 
     // Bitmap pixel (3, 2) at scale=2 → screen pixels (6, 4), (7, 4), (6, 5), (7, 5)
     // Check top-left of 2x2 block: screen row 4, col 6
@@ -359,7 +503,7 @@ test "Render: space with null glyph produces background only" {
     const stride = w * bpp;
     var buffer: [stride * h]u8 = [_]u8{0} ** (stride * h);
 
-    renderCell(&buffer, stride, 0, 0, .{ .char = ' ', .fg = 7, .bg = 0 }, null, null, null, w, h, .bgra32, false, 1, false);
+    renderCell(&buffer, stride, 0, 0, .{ .char = ' ', .fg = 7, .bg = 0 }, null, null, null, null, w, h, .bgra32, false, 1, false);
 
     try testing.expectEqual(@as(u8, 0), buffer[2]);
 

--- a/src/term.zig
+++ b/src/term.zig
@@ -752,9 +752,10 @@ pub const Term = struct {
                 } else if (self.has_truecolor_cells) {
                     @memset(self.bg_rgb[0..total], null);
                     @memset(self.fg_rgb[0..total], null);
-                    // All cells cleared — reset truecolor flag
                     self.has_truecolor_cells = false;
                 }
+                @memset(self.ul_color_rgb[0..total], null);
+                @memset(self.hyperlink_ids[0..total], 0);
                 self.has_wide_chars = false;
             },
             else => {},
@@ -984,6 +985,8 @@ pub const Term = struct {
                             self.cells[idx] = blank;
                             self.fg_rgb[idx] = null;
                             self.bg_rgb[idx] = bg_rgb_val;
+                            self.ul_color_rgb[idx] = null;
+                            self.hyperlink_ids[idx] = 0;
                         }
                     }
                 }
@@ -1000,6 +1003,8 @@ pub const Term = struct {
                             self.cells[idx] = blank;
                             self.fg_rgb[idx] = null;
                             self.bg_rgb[idx] = bg_rgb_val;
+                            self.ul_color_rgb[idx] = null;
+                            self.hyperlink_ids[idx] = 0;
                         }
                     }
                 }
@@ -1015,6 +1020,8 @@ pub const Term = struct {
                             self.cells[idx] = blank;
                             self.fg_rgb[idx] = null;
                             self.bg_rgb[idx] = bg_rgb_val;
+                            self.ul_color_rgb[idx] = null;
+                            self.hyperlink_ids[idx] = 0;
                         }
                     }
                 }

--- a/src/term.zig
+++ b/src/term.zig
@@ -36,7 +36,6 @@ pub const UnderlineStyle = struct {
 pub const HyperlinkEntry = struct {
     url: [512]u8 = undefined,
     len: u16 = 0,
-    ref_count: u16 = 0, // cells referencing this entry
 
     pub fn slice(self: *const HyperlinkEntry) []const u8 {
         return self.url[0..self.len];
@@ -117,7 +116,7 @@ pub const Term = struct {
     current_hyperlink_id: u16 = 0,
 
     // OSC 52 clipboard output
-    osc52_buf: [4096]u8 = undefined,
+    osc52_buf: [6144]u8 = undefined, // base64(8192) decodes to max ~6144 bytes
     osc52_len: u16 = 0,
     osc52_pending: bool = false,
 
@@ -909,12 +908,14 @@ pub const Term = struct {
         // Fix wide boundaries using logical coords
         self.fixWideBoundaries(logical_row_start + cx, logical_row_start + cx + count);
 
-        // Shift characters left (physical) — cells + TrueColor arrays
+        // Shift characters left (physical) — cells + TrueColor + ul_color + hyperlinks
         const copy_len = remaining - count;
         if (copy_len > 0) {
             std.mem.copyForwards(Cell, self.cells[row_base + cx .. row_base + cx + copy_len], self.cells[row_base + cx + count .. row_base + cx + count + copy_len]);
             std.mem.copyForwards(?[3]u8, self.fg_rgb[row_base + cx .. row_base + cx + copy_len], self.fg_rgb[row_base + cx + count .. row_base + cx + count + copy_len]);
             std.mem.copyForwards(?[3]u8, self.bg_rgb[row_base + cx .. row_base + cx + copy_len], self.bg_rgb[row_base + cx + count .. row_base + cx + count + copy_len]);
+            std.mem.copyForwards(?[3]u8, self.ul_color_rgb[row_base + cx .. row_base + cx + copy_len], self.ul_color_rgb[row_base + cx + count .. row_base + cx + count + copy_len]);
+            std.mem.copyForwards(u16, self.hyperlink_ids[row_base + cx .. row_base + cx + copy_len], self.hyperlink_ids[row_base + cx + count .. row_base + cx + count + copy_len]);
         }
 
         // Clear rightmost characters with BCE
@@ -940,6 +941,8 @@ pub const Term = struct {
             std.mem.copyBackwards(Cell, self.cells[row_base + cx + count .. row_base + cx + count + copy_len], self.cells[row_base + cx .. row_base + cx + copy_len]);
             std.mem.copyBackwards(?[3]u8, self.fg_rgb[row_base + cx + count .. row_base + cx + count + copy_len], self.fg_rgb[row_base + cx .. row_base + cx + copy_len]);
             std.mem.copyBackwards(?[3]u8, self.bg_rgb[row_base + cx + count .. row_base + cx + count + copy_len], self.bg_rgb[row_base + cx .. row_base + cx + copy_len]);
+            std.mem.copyBackwards(?[3]u8, self.ul_color_rgb[row_base + cx + count .. row_base + cx + count + copy_len], self.ul_color_rgb[row_base + cx .. row_base + cx + copy_len]);
+            std.mem.copyBackwards(u16, self.hyperlink_ids[row_base + cx + count .. row_base + cx + count + copy_len], self.hyperlink_ids[row_base + cx .. row_base + cx + copy_len]);
         }
 
         // Clear inserted characters with BCE

--- a/src/term.zig
+++ b/src/term.zig
@@ -11,7 +11,7 @@ pub const Cell = struct {
     pub const Attrs = packed struct(u16) {
         bold: bool = false,
         italic: bool = false,
-        underline: bool = false,
+        underline_style: u3 = 0, // 0=none, 1=single, 2=double, 3=curly, 4=dotted, 5=dashed
         reverse: bool = false,
         dim: bool = false,
         wide: bool = false,
@@ -19,9 +19,28 @@ pub const Cell = struct {
         blink: bool = false,
         invisible: bool = false,
         strikethrough: bool = false,
-        protected: bool = false, // DECSCA character protection
-        _pad: u5 = 0,
+        protected: bool = false,
+        _pad: u3 = 0,
     };
+};
+
+pub const UnderlineStyle = struct {
+    pub const none: u3 = 0;
+    pub const single: u3 = 1;
+    pub const double: u3 = 2;
+    pub const curly: u3 = 3;
+    pub const dotted: u3 = 4;
+    pub const dashed: u3 = 5;
+};
+
+pub const HyperlinkEntry = struct {
+    url: [512]u8 = undefined,
+    len: u16 = 0,
+    ref_count: u16 = 0, // cells referencing this entry
+
+    pub fn slice(self: *const HyperlinkEntry) []const u8 {
+        return self.url[0..self.len];
+    }
 };
 
 const default_cell: Cell = .{};
@@ -62,6 +81,8 @@ pub const Term = struct {
     alt_dirty: ?std.DynamicBitSet = null,
     alt_fg_rgb: ?[]?[3]u8 = null,
     alt_bg_rgb: ?[]?[3]u8 = null,
+    alt_ul_color_rgb: ?[]?[3]u8 = null,
+    alt_hyperlink_ids: ?[]u16 = null,
     is_alt_screen: bool = false,
 
     // Cursor
@@ -82,10 +103,23 @@ pub const Term = struct {
     current_attrs: Cell.Attrs = .{},
     current_fg_rgb: ?[3]u8 = null,
     current_bg_rgb: ?[3]u8 = null,
+    current_ul_color_rgb: ?[3]u8 = null,
 
     // TrueColor flat arrays (indexed by physical cell index, null = no override)
     fg_rgb: []?[3]u8,
     bg_rgb: []?[3]u8,
+    ul_color_rgb: []?[3]u8,
+
+    // Hyperlinks (indexed by physical cell index, 0 = no link)
+    hyperlink_ids: []u16,
+    hyperlink_table: [64]HyperlinkEntry = [_]HyperlinkEntry{.{}} ** 64,
+    hyperlink_next_id: u16 = 1,
+    current_hyperlink_id: u16 = 0,
+
+    // OSC 52 clipboard output
+    osc52_buf: [4096]u8 = undefined,
+    osc52_len: u16 = 0,
+    osc52_pending: bool = false,
 
     // Last printed graphic character (for REP / CSI b)
     last_printed_char: u21 = 0,
@@ -148,6 +182,7 @@ pub const Term = struct {
     saved_origin_mode: bool = false,
     saved_fg_rgb: ?[3]u8 = null,
     saved_bg_rgb: ?[3]u8 = null,
+    saved_ul_color_rgb: ?[3]u8 = null,
 
     pub fn init(allocator: Allocator, cols: u32, rows: u32) !Self {
         const total = @as(usize, cols) * @as(usize, rows);
@@ -163,6 +198,10 @@ pub const Term = struct {
         @memset(fg_rgb, null);
         const bg_rgb = try allocator.alloc(?[3]u8, total);
         @memset(bg_rgb, null);
+        const ul_color_rgb = try allocator.alloc(?[3]u8, total);
+        @memset(ul_color_rgb, null);
+        const hyperlink_ids = try allocator.alloc(u16, total);
+        @memset(hyperlink_ids, 0);
 
         // Initialize tab stops every 8 columns
         const tabs = try allocator.alloc(bool, cols);
@@ -180,6 +219,8 @@ pub const Term = struct {
             .scroll_bottom = rows -| 1,
             .fg_rgb = fg_rgb,
             .bg_rgb = bg_rgb,
+            .ul_color_rgb = ul_color_rgb,
+            .hyperlink_ids = hyperlink_ids,
             .tabs = tabs,
         };
     }
@@ -196,8 +237,12 @@ pub const Term = struct {
         }
         if (self.alt_fg_rgb) |a| self.allocator.free(a);
         if (self.alt_bg_rgb) |a| self.allocator.free(a);
+        if (self.alt_ul_color_rgb) |a| self.allocator.free(a);
+        if (self.alt_hyperlink_ids) |a| self.allocator.free(a);
         self.allocator.free(self.fg_rgb);
         self.allocator.free(self.bg_rgb);
+        self.allocator.free(self.ul_color_rgb);
+        self.allocator.free(self.hyperlink_ids);
     }
 
     /// Physical cell index via row_map indirection
@@ -228,6 +273,8 @@ pub const Term = struct {
         self.dirty_flag = true;
         self.fg_rgb[phys_idx] = null;
         self.bg_rgb[phys_idx] = null;
+        self.ul_color_rgb[phys_idx] = null;
+        self.hyperlink_ids[phys_idx] = 0;
     }
 
     pub fn isDirty(self: *const Self, x: u32, y: u32) bool {
@@ -394,6 +441,14 @@ pub const Term = struct {
         errdefer self.allocator.free(new_bg_rgb);
         @memset(new_bg_rgb, null);
 
+        const new_ul_color_rgb = try self.allocator.alloc(?[3]u8, new_total);
+        errdefer self.allocator.free(new_ul_color_rgb);
+        @memset(new_ul_color_rgb, null);
+
+        const new_hyperlink_ids = try self.allocator.alloc(u16, new_total);
+        errdefer self.allocator.free(new_hyperlink_ids);
+        @memset(new_hyperlink_ids, 0);
+
         const new_dirty = try std.DynamicBitSet.initFull(self.allocator, new_total);
         errdefer @constCast(&new_dirty).deinit();
 
@@ -413,6 +468,8 @@ pub const Term = struct {
             @memcpy(new_cells[new_start .. new_start + copy_cols], self.cells[old_start .. old_start + copy_cols]);
             @memcpy(new_fg_rgb[new_start .. new_start + copy_cols], self.fg_rgb[old_start .. old_start + copy_cols]);
             @memcpy(new_bg_rgb[new_start .. new_start + copy_cols], self.bg_rgb[old_start .. old_start + copy_cols]);
+            @memcpy(new_ul_color_rgb[new_start .. new_start + copy_cols], self.ul_color_rgb[old_start .. old_start + copy_cols]);
+            @memcpy(new_hyperlink_ids[new_start .. new_start + copy_cols], self.hyperlink_ids[old_start .. old_start + copy_cols]);
         }
 
         // Fix wide char boundaries broken by column truncation
@@ -425,6 +482,8 @@ pub const Term = struct {
                     new_cells[last] = blank;
                     new_fg_rgb[last] = null;
                     new_bg_rgb[last] = null;
+                    new_ul_color_rgb[last] = null;
+                    new_hyperlink_ids[last] = 0;
                 }
                 // Orphaned wide_dummy at first column (wide cell was in previous row's truncated area)
                 const first = y * @as(usize, new_cols);
@@ -432,6 +491,8 @@ pub const Term = struct {
                     new_cells[first] = blank;
                     new_fg_rgb[first] = null;
                     new_bg_rgb[first] = null;
+                    new_ul_color_rgb[first] = null;
+                    new_hyperlink_ids[first] = 0;
                 }
             }
         }
@@ -441,6 +502,8 @@ pub const Term = struct {
         self.allocator.free(self.row_map);
         self.allocator.free(self.fg_rgb);
         self.allocator.free(self.bg_rgb);
+        self.allocator.free(self.ul_color_rgb);
+        self.allocator.free(self.hyperlink_ids);
         if (self.tabs.len > 0) self.allocator.free(self.tabs);
         self.dirty.deinit();
 
@@ -448,6 +511,8 @@ pub const Term = struct {
         self.row_map = new_row_map;
         self.fg_rgb = new_fg_rgb;
         self.bg_rgb = new_bg_rgb;
+        self.ul_color_rgb = new_ul_color_rgb;
+        self.hyperlink_ids = new_hyperlink_ids;
         self.dirty = new_dirty;
         self.dirty_flag = true;
         self.all_dirty = true;
@@ -474,6 +539,10 @@ pub const Term = struct {
             const new_alt_fg = if (self.alt_fg_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
             errdefer if (new_alt_fg) |nafg| self.allocator.free(nafg);
             const new_alt_bg = if (self.alt_bg_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
+            errdefer if (new_alt_bg) |nabg| self.allocator.free(nabg);
+            const new_alt_ul = if (self.alt_ul_color_rgb != null) try self.allocator.alloc(?[3]u8, new_total) else null;
+            errdefer if (new_alt_ul) |naul| self.allocator.free(naul);
+            const new_alt_hl = if (self.alt_hyperlink_ids != null) try self.allocator.alloc(u16, new_total) else null;
 
             // All allocations succeeded — now free old and swap
             if (self.alt_cells) |alt| self.allocator.free(alt);
@@ -481,6 +550,8 @@ pub const Term = struct {
             if (self.alt_dirty) |*ad| ad.deinit();
             if (self.alt_fg_rgb) |a| self.allocator.free(a);
             if (self.alt_bg_rgb) |a| self.allocator.free(a);
+            if (self.alt_ul_color_rgb) |a| self.allocator.free(a);
+            if (self.alt_hyperlink_ids) |a| self.allocator.free(a);
 
             if (new_alt_cells) |nac| @memset(nac, Cell{});
             self.alt_cells = new_alt_cells;
@@ -493,6 +564,10 @@ pub const Term = struct {
             self.alt_fg_rgb = new_alt_fg;
             if (new_alt_bg) |nbg| @memset(nbg, null);
             self.alt_bg_rgb = new_alt_bg;
+            if (new_alt_ul) |nul| @memset(nul, null);
+            self.alt_ul_color_rgb = new_alt_ul;
+            if (new_alt_hl) |nhl| @memset(nhl, 0);
+            self.alt_hyperlink_ids = new_alt_hl;
         }
     }
 
@@ -512,9 +587,13 @@ pub const Term = struct {
             @memset(self.alt_fg_rgb.?, null);
             self.alt_bg_rgb = try self.allocator.alloc(?[3]u8, total);
             @memset(self.alt_bg_rgb.?, null);
+            self.alt_ul_color_rgb = try self.allocator.alloc(?[3]u8, total);
+            @memset(self.alt_ul_color_rgb.?, null);
+            self.alt_hyperlink_ids = try self.allocator.alloc(u16, total);
+            @memset(self.alt_hyperlink_ids.?, 0);
         }
 
-        // Swap main <-> alt (cells, row_map, dirty, TrueColor)
+        // Swap main <-> alt (cells, row_map, dirty, TrueColor, ul_color, hyperlinks)
         const tmp_cells = self.cells;
         self.cells = self.alt_cells.?;
         self.alt_cells = tmp_cells;
@@ -534,6 +613,14 @@ pub const Term = struct {
         const tmp_bg = self.bg_rgb;
         self.bg_rgb = self.alt_bg_rgb.?;
         self.alt_bg_rgb = tmp_bg;
+
+        const tmp_ul = self.ul_color_rgb;
+        self.ul_color_rgb = self.alt_ul_color_rgb.?;
+        self.alt_ul_color_rgb = tmp_ul;
+
+        const tmp_hl = self.hyperlink_ids;
+        self.hyperlink_ids = self.alt_hyperlink_ids.?;
+        self.alt_hyperlink_ids = tmp_hl;
 
         self.is_alt_screen = alt;
         self.markDirtyRange(.{ .start = 0, .end = total });
@@ -590,6 +677,8 @@ pub const Term = struct {
             @memset(self.bg_rgb[phys_start..phys_end], null);
             @memset(self.fg_rgb[phys_start..phys_end], null);
         }
+        @memset(self.ul_color_rgb[phys_start..phys_end], null);
+        @memset(self.hyperlink_ids[phys_start..phys_end], 0);
     }
 
     /// Fix wide character boundaries at the edges of an erase/delete range.

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -542,6 +542,9 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                     @memset(term.fg_rgb[phys_start .. phys_start + count], null);
                     @memset(term.bg_rgb[phys_start .. phys_start + count], null);
                 }
+                // Underline color + hyperlink metadata
+                @memset(term.ul_color_rgb[phys_start .. phys_start + count], term.current_ul_color_rgb);
+                @memset(term.hyperlink_ids[phys_start .. phys_start + count], term.current_hyperlink_id);
                 // Bulk dirty (logical index)
                 const logical_start = @as(usize, term.cursor_y) * @as(usize, cols) + term.cursor_x;
                 term.markDirtyRange(.{ .start = logical_start, .end = logical_start + count });
@@ -682,6 +685,8 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
                     term.fg_rgb[phys_idx] = null;
                     term.bg_rgb[phys_idx] = null;
                 }
+                term.ul_color_rgb[phys_idx] = term.current_ul_color_rgb;
+                term.hyperlink_ids[phys_idx] = term.current_hyperlink_id;
                 const logical_idx = @as(usize, term.cursor_y) * @as(usize, cols) + term.cursor_x;
                 dirty_run_end = logical_idx + 1;
                 term.last_printed_char = cp;
@@ -825,7 +830,6 @@ fn handleOsc8(param: []const u8, term: *Term) void {
     const slot = (term.hyperlink_next_id - 1) % 64;
     term.hyperlink_table[slot].len = @intCast(max_len);
     @memcpy(term.hyperlink_table[slot].url[0..max_len], uri[0..max_len]);
-    term.hyperlink_table[slot].ref_count = 0;
     term.current_hyperlink_id = slot + 1;
     term.hyperlink_next_id +%= 1;
     if (term.hyperlink_next_id == 0) term.hyperlink_next_id = 1;
@@ -1602,7 +1606,8 @@ fn resetSgr(term: *Term) void {
     term.current_fg_rgb = null;
     term.current_bg_rgb = null;
     term.current_ul_color_rgb = null;
-    term.current_hyperlink_id = 0;
+    // Note: current_hyperlink_id is NOT reset by SGR 0.
+    // Hyperlinks are controlled exclusively by OSC 8, not SGR.
 }
 
 fn parseUnderlineColor(p: [16]u16, pc: u8, start: u8, term: *Term) u8 {

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -1163,6 +1163,8 @@ fn handlePrint(cp: u21, term: *Term) void {
                 term.fg_rgb[dummy_phys] = null;
                 term.bg_rgb[dummy_phys] = null;
             }
+            term.ul_color_rgb[dummy_phys] = term.current_ul_color_rgb;
+            term.hyperlink_ids[dummy_phys] = term.current_hyperlink_id;
             const dummy_dirty = @as(usize, term.cursor_y) * cols + @as(usize, term.cursor_x - 1);
             term.dirty.set(dummy_dirty);
         }

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -10,6 +10,8 @@ const testing = std.testing;
 
 pub const CsiAction = struct {
     params: [16]u16 = [_]u16{0} ** 16,
+    sub_params: [16]u16 = [_]u16{0} ** 16,
+    has_sub: u16 = 0, // bitmask: bit i set = params[i] has a sub-param
     param_count: u8 = 0,
     intermediates: [2]u8 = [_]u8{0} ** 2,
     intermediate_count: u8 = 0,
@@ -60,12 +62,14 @@ pub const Parser = struct {
     intermediate_count: u8 = 0,
     private_marker: u8 = 0,
     in_subparam: bool = false,
+    sub_params: [16]u16 = [_]u16{0} ** 16,
+    has_sub: u16 = 0, // bitmask: bit i set = params[i] has a sub-param
     // UTF-8 accumulator
     utf8_buf: [4]u8 = undefined,
     utf8_len: u3 = 0,
     utf8_expected: u3 = 0,
     // OSC accumulator
-    osc_buf: [256]u8 = undefined,
+    osc_buf: [8192]u8 = undefined,
     osc_len: u16 = 0,
     // ESC in OSC tracking
     esc_in_osc: bool = false,
@@ -261,17 +265,30 @@ pub const Parser = struct {
 
     fn handleCsiParam(self: *Parser, byte: u8) Action {
         if (byte >= '0' and byte <= '9') {
-            // Accumulate digit (skip if in colon sub-parameter)
-            if (self.in_subparam) return .none;
-            const idx = self.param_count;
-            if (idx < 16) {
-                self.params[idx] = self.params[idx] *| 10 +| (byte - '0');
+            if (self.in_subparam) {
+                // Accumulate first colon sub-parameter digit
+                const idx = self.param_count;
+                if (idx < 16) {
+                    self.sub_params[idx] = self.sub_params[idx] *| 10 +| (byte - '0');
+                }
+            } else {
+                const idx = self.param_count;
+                if (idx < 16) {
+                    self.params[idx] = self.params[idx] *| 10 +| (byte - '0');
+                }
             }
             return .none;
         } else if (byte == ':') {
             // Colon sub-parameter separator (e.g., \e[4:3m)
-            // Keep the main parameter, skip sub-parameter digits
-            self.in_subparam = true;
+            if (!self.in_subparam) {
+                // First colon: mark this param as having a sub-param
+                const idx = self.param_count;
+                if (idx < 16) {
+                    self.has_sub |= @as(u16, 1) << @intCast(idx);
+                }
+                self.in_subparam = true;
+            }
+            // Subsequent colons (e.g., 58:2::r:g:b) — ignore for now
             return .none;
         } else if (byte == ';') {
             // Next param — ends any sub-parameter
@@ -332,11 +349,11 @@ pub const Parser = struct {
                 return Action{ .osc_dispatch = self.osc_buf[0..self.osc_len] };
             }
             // Not ST, store the ESC and this byte
-            if (self.osc_len < 256) {
+            if (self.osc_len < 8192) {
                 self.osc_buf[self.osc_len] = 0x1B;
                 self.osc_len += 1;
             }
-            if (self.osc_len < 256) {
+            if (self.osc_len < 8192) {
                 self.osc_buf[self.osc_len] = byte;
                 self.osc_len += 1;
             }
@@ -352,7 +369,7 @@ pub const Parser = struct {
             self.esc_in_osc = true;
             return .none;
         } else {
-            if (self.osc_len < 256) {
+            if (self.osc_len < 8192) {
                 self.osc_buf[self.osc_len] = byte;
                 self.osc_len += 1;
             }
@@ -374,7 +391,7 @@ pub const Parser = struct {
                 return if (payload.len > 0) Action{ .dcs_dispatch = payload } else .none;
             } else {
                 // ESC followed by non-backslash — store the ESC and reprocess byte
-                if (self.osc_len < 256) {
+                if (self.osc_len < 8192) {
                     self.osc_buf[self.osc_len] = 0x1B;
                     self.osc_len += 1;
                 }
@@ -386,7 +403,7 @@ pub const Parser = struct {
             self.esc_in_osc = true;
             return .none;
         } else {
-            if (self.osc_len < 256) {
+            if (self.osc_len < 8192) {
                 self.osc_buf[self.osc_len] = byte;
                 self.osc_len += 1;
             }
@@ -396,6 +413,8 @@ pub const Parser = struct {
 
     fn clearCsi(self: *Parser) void {
         self.params = [_]u16{0} ** 16;
+        self.sub_params = [_]u16{0} ** 16;
+        self.has_sub = 0;
         self.param_count = 0;
         self.intermediates = [_]u8{0} ** 2;
         self.intermediate_count = 0;
@@ -406,6 +425,8 @@ pub const Parser = struct {
     fn buildCsiAction(self: *const Parser, final_byte: u8) CsiAction {
         return CsiAction{
             .params = self.params,
+            .sub_params = self.sub_params,
+            .has_sub = self.has_sub,
             .param_count = self.param_count,
             .intermediates = self.intermediates,
             .intermediate_count = self.intermediate_count,
@@ -731,7 +752,7 @@ fn handleOsc(payload: []const u8, term: *Term, writer_fd: ?std.posix.fd_t) void 
         1 => {}, // Set icon name only — silently accept
         4 => {}, // Set color palette — silently accept
         7 => {}, // Set working directory — silently accept
-        8 => {}, // Hyperlinks — silently accept
+        8 => handleOsc8(param, term),
         10, 11, 12 => {
             // Dynamic color query: param == "?" means query
             if (std.mem.eql(u8, param, "?")) {
@@ -746,10 +767,68 @@ fn handleOsc(payload: []const u8, term: *Term, writer_fd: ?std.posix.fd_t) void 
                 }
             }
         },
-        52 => {}, // Clipboard — silently accept
+        52 => handleOsc52(param, term),
         104, 110, 111, 112 => {}, // Reset colors — silently accept
         else => {},
     }
+}
+
+fn handleOsc52(param: []const u8, term: *Term) void {
+    // OSC 52 ; Pc ; Pd ST
+    // Pc = clipboard selection (c, p, s, etc.), Pd = base64 data or "?" for query
+    const sep = std.mem.indexOfScalar(u8, param, ';');
+    const b64_data = if (sep) |s| param[s + 1 ..] else param;
+
+    // Query ("?") — not supported for security reasons
+    if (b64_data.len == 1 and b64_data[0] == '?') return;
+    // Clear ("") — clear clipboard
+    if (b64_data.len == 0) {
+        term.osc52_len = 0;
+        term.osc52_pending = true;
+        return;
+    }
+
+    // Base64 decode
+    const decoder = std.base64.standard.Decoder;
+    const decoded_len = decoder.calcSizeForSlice(b64_data) catch return;
+    if (decoded_len > term.osc52_buf.len) return; // too large
+    decoder.decode(&term.osc52_buf, b64_data) catch return;
+    term.osc52_len = @intCast(decoded_len);
+    term.osc52_pending = true;
+}
+
+fn handleOsc8(param: []const u8, term: *Term) void {
+    // OSC 8 ; params ; URI ST  (start hyperlink)
+    // OSC 8 ; ; ST             (end hyperlink)
+    // Format: params;URI — find second semicolon
+    const first_sep = std.mem.indexOfScalar(u8, param, ';') orelse return;
+    const uri = param[first_sep + 1 ..];
+
+    if (uri.len == 0) {
+        // End hyperlink
+        term.current_hyperlink_id = 0;
+        return;
+    }
+
+    // Start hyperlink — find or create entry
+    const max_len = @min(uri.len, @as(usize, 512));
+
+    // Search existing entries
+    for (&term.hyperlink_table, 0..) |*entry, idx| {
+        if (entry.len == max_len and std.mem.eql(u8, entry.url[0..entry.len], uri[0..max_len])) {
+            term.current_hyperlink_id = @intCast(idx + 1);
+            return;
+        }
+    }
+
+    // Allocate new entry (ring buffer)
+    const slot = (term.hyperlink_next_id - 1) % 64;
+    term.hyperlink_table[slot].len = @intCast(max_len);
+    @memcpy(term.hyperlink_table[slot].url[0..max_len], uri[0..max_len]);
+    term.hyperlink_table[slot].ref_count = 0;
+    term.current_hyperlink_id = slot + 1;
+    term.hyperlink_next_id +%= 1;
+    if (term.hyperlink_next_id == 0) term.hyperlink_next_id = 1;
 }
 
 fn handleDcsDispatch(payload: []const u8, writer_fd: ?std.posix.fd_t, term: *const Term) void {
@@ -1053,6 +1132,13 @@ fn handlePrint(cp: u21, term: *Term) void {
         term.fg_rgb[phys_idx] = null;
         term.bg_rgb[phys_idx] = null;
     }
+    // Underline color + hyperlink: only write when active (avoid touching cache lines)
+    if (term.current_ul_color_rgb != null) {
+        term.ul_color_rgb[phys_idx] = term.current_ul_color_rgb;
+    } else {
+        term.ul_color_rgb[phys_idx] = null;
+    }
+    term.hyperlink_ids[phys_idx] = term.current_hyperlink_id;
     const dirty_idx = @as(usize, term.cursor_y) * cols + @as(usize, term.cursor_x);
     term.dirty.set(dirty_idx);
     term.dirty_flag = true;
@@ -1422,18 +1508,26 @@ fn handleSgr(csi: CsiAction, term: *Term) void {
             1 => term.current_attrs.bold = true,
             2 => term.current_attrs.dim = true,
             3 => term.current_attrs.italic = true,
-            4 => term.current_attrs.underline = true,
+            4 => {
+                // Check for sub-param (4:N styled underline)
+                if (csi.has_sub & (@as(u16, 1) << @intCast(i)) != 0) {
+                    const style = csi.sub_params[i];
+                    term.current_attrs.underline_style = if (style <= 5) @intCast(style) else 1;
+                } else {
+                    term.current_attrs.underline_style = 1; // single
+                }
+            },
             5, 6 => term.current_attrs.blink = true, // slow/rapid blink
             7 => term.current_attrs.reverse = true,
             8 => term.current_attrs.invisible = true,
             9 => term.current_attrs.strikethrough = true,
-            21 => term.current_attrs.underline = true, // Doubly-underlined (treated as underline)
+            21 => term.current_attrs.underline_style = 2, // double underline
             22 => {
                 term.current_attrs.bold = false;
                 term.current_attrs.dim = false;
             },
             23 => term.current_attrs.italic = false,
-            24 => term.current_attrs.underline = false,
+            24 => term.current_attrs.underline_style = 0,
             25 => term.current_attrs.blink = false,
             27 => term.current_attrs.reverse = false,
             28 => term.current_attrs.invisible = false,
@@ -1458,17 +1552,9 @@ fn handleSgr(csi: CsiAction, term: *Term) void {
             },
             58 => {
                 // Extended underline color (58;2;r;g;b or 58;5;n)
-                // Must consume sub-params so they aren't misread as SGR codes
-                if (i + 1 < pc) {
-                    const sub = p[i + 1];
-                    if (sub == 5 and i + 2 < pc) {
-                        i = i + 2;
-                    } else if (sub == 2 and i + 4 < pc) {
-                        i = i + 4;
-                    }
-                }
+                i = parseUnderlineColor(p, pc, i, term);
             },
-            59 => {},
+            59 => term.current_ul_color_rgb = null,
             90...97 => term.current_fg = @intCast(param - 90 + 8),
             100...107 => term.current_bg = @intCast(param - 100 + 8),
             else => {},
@@ -1515,6 +1601,36 @@ fn resetSgr(term: *Term) void {
     term.current_attrs = .{};
     term.current_fg_rgb = null;
     term.current_bg_rgb = null;
+    term.current_ul_color_rgb = null;
+    term.current_hyperlink_id = 0;
+}
+
+fn parseUnderlineColor(p: [16]u16, pc: u8, start: u8, term: *Term) u8 {
+    const i = start;
+    if (i + 1 < pc) {
+        const sub = p[i + 1];
+        if (sub == 5 and i + 2 < pc) {
+            // 58;5;n — 256-color underline
+            if (p[i + 2] <= 255) {
+                const color: u8 = @intCast(p[i + 2]);
+                const render = @import("render.zig");
+                const c = render.palette[color];
+                term.current_ul_color_rgb = .{ c.r, c.g, c.b };
+            }
+            return i + 2;
+        } else if (sub == 2 and i + 4 < pc) {
+            // 58;2;r;g;b — TrueColor underline
+            if (p[i + 2] <= 255 and p[i + 3] <= 255 and p[i + 4] <= 255) {
+                term.current_ul_color_rgb = .{
+                    @intCast(p[i + 2]),
+                    @intCast(p[i + 3]),
+                    @intCast(p[i + 4]),
+                };
+            }
+            return i + 4;
+        }
+    }
+    return i;
 }
 
 fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
@@ -1633,6 +1749,7 @@ fn handleEsc(esc: EscAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             term.saved_bg = term.current_bg;
             term.saved_fg_rgb = term.current_fg_rgb;
             term.saved_bg_rgb = term.current_bg_rgb;
+            term.saved_ul_color_rgb = term.current_ul_color_rgb;
             term.saved_charset = term.charset;
             term.saved_wrap_next = term.wrap_next;
             term.saved_origin_mode = term.origin_mode;
@@ -1645,6 +1762,7 @@ fn handleEsc(esc: EscAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             term.current_bg = term.saved_bg;
             term.current_fg_rgb = term.saved_fg_rgb;
             term.current_bg_rgb = term.saved_bg_rgb;
+            term.current_ul_color_rgb = term.saved_ul_color_rgb;
             term.charset = term.saved_charset;
             term.wrap_next = term.saved_wrap_next;
             term.origin_mode = term.saved_origin_mode;
@@ -1716,6 +1834,9 @@ fn handleEsc(esc: EscAction, term: *Term, writer_fd: ?std.posix.fd_t) void {
             term.saved_charset = 0;
             term.saved_wrap_next = false;
             term.saved_origin_mode = false;
+            term.saved_ul_color_rgb = null;
+            term.current_ul_color_rgb = null;
+            term.current_hyperlink_id = 0;
             term.saved_fg_rgb = null;
             term.saved_bg_rgb = null;
             for (0..term.tabs.len) |c| {


### PR DESCRIPTION
## **User description**
## Summary
- **OSC 52 Clipboard**: base64デコード → xclip/wl-copy経由でシステムクリップボードへ書き込み。OSCバッファを256→8192に拡大
- **Styled Underlines (SGR 4:0〜4:5, 58;2/5)**: underline boolをu3 underline_styleに変更。single/double/curly/dotted/dashedの5スタイル描画対応。underline color (256色/TrueColor) 対応
- **OSC 8 Hyperlinks**: per-cell hyperlink_idで64エントリURL ring buffer管理。OSC 8 params;URIパース＋URL重複検出

## Changes
- `term.zig`: Cell.Attrs拡張、ul_color_rgb/hyperlink_ids parallel array追加、resize/switchScreen/bceMemset対応
- `vt.zig`: CSI sub-paramキャプチャ、SGR 4:N/58/59、OSC 52/8ハンドラ、DECSC/DECRC ul_color保存
- `render.zig`: 5 underlineスタイル描画関数、underline color対応
- `main.zig`: dispatchClipboardCopy (fork+exec)、ul_color renderパス追加

## Test plan
- [ ] `zig build test` パス確認
- [ ] neovim/helixでcurly underline表示確認 (SGR 4:3)
- [ ] `printf '\e]52;c;SGVsbG8=\a'` でクリップボードに "Hello" が入ることを確認
- [ ] `printf '\e]8;;https://example.com\e\\Click\e]8;;\e\\'` でhyperlink cellが保存されることを確認
- [ ] `ls --hyperlink=auto` の出力が壊れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add clipboard copy, styled underlines, and clickable terminal links**

### What Changed
- OSC 52 clipboard text is now copied to the system clipboard on X11 and Wayland instead of being ignored
- Underlines can now appear as single, double, curly, dotted, or dashed, and can use a separate underline color
- OSC 8 hyperlinks are now tracked per cell so linked text can be recognized across the screen, including after resizing and switching screens

### Impact
`✅ Copy to system clipboard from terminal apps`
`✅ Clearer link display in terminal output`
`✅ Accurate styled underlines in compatible apps`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * クリップボードへOSC 52経由でコピーする機能を追加
  * 下線スタイル（単線・二重・波線・点線・破線）と下線色のセル単位カスタマイズを追加
  * ターミナル内ハイパーリンクのサポートを追加

* **不具合修正／改善**
  * 子プロセスの終了処理（ゾンビ防止）を改善し安定性を向上
<!-- end of auto-generated comment: release notes by coderabbit.ai -->