### PR TITLE
Fix Codex review findings: bracketed paste, resize, DECOM, and more

### DIFF
--- a/src/backend/fbdev.zig
+++ b/src/backend/fbdev.zig
@@ -132,9 +132,18 @@ pub const FbdevBackend = struct {
         const fb_size = finfo.line_length * vinfo.yres;
         const bpp = vinfo.bits_per_pixel / 8;
 
-        // Render loop hardcodes BGRA32 — reject unsupported pixel formats
-        if (bpp != 4) {
-            std.log.err("fbdev: unsupported {d}bpp framebuffer (only 32bpp BGRA supported)", .{vinfo.bits_per_pixel});
+        // Render loop hardcodes BGRA32 — validate pixel format and channel layout
+        if (bpp != 4 or
+            vinfo.blue.offset != 0 or vinfo.blue.length != 8 or
+            vinfo.green.offset != 8 or vinfo.green.length != 8 or
+            vinfo.red.offset != 16 or vinfo.red.length != 8)
+        {
+            std.log.err("fbdev: unsupported pixel format (need 32bpp BGRA, got {d}bpp R@{d}/{d} G@{d}/{d} B@{d}/{d})", .{
+                vinfo.bits_per_pixel,
+                vinfo.red.offset,   vinfo.red.length,
+                vinfo.green.offset, vinfo.green.length,
+                vinfo.blue.offset,  vinfo.blue.length,
+            });
             return error.UnsupportedPixelFormat;
         }
 

--- a/src/backend/fbdev.zig
+++ b/src/backend/fbdev.zig
@@ -132,6 +132,12 @@ pub const FbdevBackend = struct {
         const fb_size = finfo.line_length * vinfo.yres;
         const bpp = vinfo.bits_per_pixel / 8;
 
+        // Render loop hardcodes BGRA32 — reject unsupported pixel formats
+        if (bpp != 4) {
+            std.log.err("fbdev: unsupported {d}bpp framebuffer (only 32bpp BGRA supported)", .{vinfo.bits_per_pixel});
+            return error.UnsupportedPixelFormat;
+        }
+
         // 4. mmap the framebuffer
         const fb_mem = try std.posix.mmap(
             null,

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -940,7 +940,7 @@ pub const WaylandBackend = struct {
                     // Shift+Insert -> primary selection paste
                     if (evdev_keycode == input_mod.KEY.INSERT and mods.shift) {
                         if (self.clipboard.primary_offer_id != 0 and self.clipboard.primary_has_text) {
-                            clipboard_mod.requestPaste(&self.conn, self.clipboard.primary_offer_id, &self.clipboard) catch {};
+                            clipboard_mod.requestPaste(&self.conn, self.clipboard.primary_offer_id, &self.clipboard, clipboard_mod.ZWP_PRIMARY_SELECTION_OFFER_RECEIVE) catch {};
                             if (self.clipboard.paste_pipe_fd >= 0) {
                                 var epev = linux.epoll_event{
                                     .events = linux.EPOLL.IN | linux.EPOLL.HUP,
@@ -955,7 +955,7 @@ pub const WaylandBackend = struct {
                     // Ctrl+Shift+V -> clipboard paste
                     if (evdev_keycode == input_mod.KEY.V and mods.ctrl and mods.shift) {
                         if (self.clipboard.current_offer_id != 0 and self.clipboard.offer_has_text) {
-                            clipboard_mod.requestPaste(&self.conn, self.clipboard.current_offer_id, &self.clipboard) catch {};
+                            clipboard_mod.requestPaste(&self.conn, self.clipboard.current_offer_id, &self.clipboard, clipboard_mod.WL_DATA_OFFER_RECEIVE) catch {};
                             if (self.clipboard.paste_pipe_fd >= 0) {
                                 var epev = linux.epoll_event{
                                     .events = linux.EPOLL.IN | linux.EPOLL.HUP,

--- a/src/backend/wayland/clipboard.zig
+++ b/src/backend/wayland/clipboard.zig
@@ -130,6 +130,7 @@ pub fn requestPaste(
     const fds = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
     const read_fd = fds[0];
     const write_fd = fds[1];
+    defer posix.close(write_fd); // always close write end (compositor gets dup via SCM_RIGHTS)
     errdefer posix.close(read_fd);
 
     const mime = "text/plain;charset=utf-8";
@@ -141,9 +142,6 @@ pub fn requestPaste(
     wire.putString(&payload, &pos, mime);
 
     try conn.sendMessage(offer_id, opcode, payload[0..pos], &[_]posix.fd_t{write_fd});
-
-    // Close write end — compositor has a duplicate via SCM_RIGHTS
-    posix.close(write_fd);
 
     // Flush immediately so the compositor processes the receive request
     try conn.flush();

--- a/src/backend/wayland/clipboard.zig
+++ b/src/backend/wayland/clipboard.zig
@@ -124,6 +124,7 @@ pub fn requestPaste(
     conn: *wire.Connection,
     offer_id: u32,
     state: *ClipboardState,
+    opcode: u16,
 ) !void {
     // Create a non-blocking, close-on-exec pipe pair
     const fds = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
@@ -139,7 +140,7 @@ pub fn requestPaste(
     var pos: usize = 0;
     wire.putString(&payload, &pos, mime);
 
-    try conn.sendMessage(offer_id, WL_DATA_OFFER_RECEIVE, payload[0..pos], &[_]posix.fd_t{write_fd});
+    try conn.sendMessage(offer_id, opcode, payload[0..pos], &[_]posix.fd_t{write_fd});
 
     // Close write end — compositor has a duplicate via SCM_RIGHTS
     posix.close(write_fd);

--- a/src/backend/wayland/wire.zig
+++ b/src/backend/wayland/wire.zig
@@ -115,12 +115,14 @@ pub fn putString(buf: []u8, pos: *usize, str: []const u8) void {
 }
 
 pub fn getUint(buf: []const u8, pos: *usize) u32 {
+    if (pos.* + 4 > buf.len) return 0; // bounds check
     const value = std.mem.readInt(u32, buf[pos.*..][0..4], .little);
     pos.* += 4;
     return value;
 }
 
 pub fn getInt(buf: []const u8, pos: *usize) i32 {
+    if (pos.* + 4 > buf.len) return 0; // bounds check
     const value = std.mem.readInt(i32, buf[pos.*..][0..4], .little);
     pos.* += 4;
     return value;
@@ -132,8 +134,12 @@ pub fn getInt(buf: []const u8, pos: *usize) i32 {
 pub fn getString(buf: []const u8, pos: *usize) []const u8 {
     const len = getUint(buf, pos);
     if (len == 0) return buf[0..0]; // empty/null string
-    const str = buf[pos.*..][0 .. len - 1]; // exclude null terminator
     const padded = alignUp(len, 4);
+    if (pos.* + padded > buf.len or len - 1 > buf.len - pos.*) {
+        pos.* = buf.len; // skip to end on malformed
+        return buf[0..0];
+    }
+    const str = buf[pos.*..][0 .. len - 1]; // exclude null terminator
     pos.* += padded;
     return str;
 }
@@ -143,8 +149,12 @@ pub fn getString(buf: []const u8, pos: *usize) []const u8 {
 /// Advances pos past the padded end.
 pub fn getArray(buf: []const u8, pos: *usize) []const u8 {
     const len = getUint(buf, pos);
-    const data = buf[pos.*..][0..len];
     const padded = alignUp(len, 4);
+    if (pos.* + padded > buf.len or len > buf.len - pos.*) {
+        pos.* = buf.len; // skip to end on malformed
+        return buf[0..0];
+    }
+    const data = buf[pos.*..][0..len];
     pos.* += padded;
     return data;
 }

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -89,8 +89,10 @@ pub const X11Backend = struct {
     committed_text: TextEvent = .{},
     has_committed: bool = false,
     forwarded_keycode: u8 = 0, // XCB keycode (detail) from forward_event callback
+    forwarded_mods: input_mod.Modifiers = .{}, // modifiers from forwarded key
     has_forwarded_key: bool = false,
     pending_xim_keycode: u8 = 0, // key sent to IM, awaiting response
+    pending_xim_mods: input_mod.Modifiers = .{}, // modifiers from pending XIM key
     has_pending_xim: bool = false,
     xim_pending_ns: i128 = 0, // timestamp when XIM key was forwarded (for timeout)
     suppress_xim_result: bool = false, // discard next XIM result (IME toggle key)
@@ -411,12 +413,13 @@ pub const X11Backend = struct {
     }
 
     /// Convert an XCB keycode (detail) to an Event using XKB or fallback keymap.
-    fn processKeycode(self: *Self, xcb_keycode: u8) ?Event {
+    /// Preserves modifiers from the original X event for correct key translation.
+    fn processKeycode(self: *Self, xcb_keycode: u8, mods: input_mod.Modifiers) ?Event {
         const evdev_keycode: u16 = @as(u16, xcb_keycode) -| 8;
 
-        // Special keys → KeyEvent
+        // Special keys → KeyEvent (preserve modifiers)
         if (isSpecialKey(evdev_keycode)) {
-            return .{ .key = .{ .keycode = evdev_keycode, .pressed = true, .modifiers = .{} } };
+            return .{ .key = .{ .keycode = evdev_keycode, .pressed = true, .modifiers = mods } };
         }
 
         // XKB text translation
@@ -433,8 +436,8 @@ pub const X11Backend = struct {
             }
         }
 
-        // Fallback
-        return .{ .key = .{ .keycode = evdev_keycode, .pressed = true, .modifiers = .{} } };
+        // Fallback (preserve modifiers)
+        return .{ .key = .{ .keycode = evdev_keycode, .pressed = true, .modifiers = mods } };
     }
 
     fn initXim(self: *Self) void {
@@ -551,6 +554,7 @@ pub const X11Backend = struct {
             const is_press = (ev.response_type & 0x7F) == c.XCB_KEY_PRESS;
             if (!is_press) return; // ignore key release from IM
             self.forwarded_keycode = ev.detail;
+            self.forwarded_mods = xcbStateToMods(ev.state);
             self.has_forwarded_key = true;
             self.has_pending_xim = false;
         }
@@ -773,7 +777,7 @@ pub const X11Backend = struct {
                 self.has_pending_xim = false;
                 // Fall back to local XKB processing for the stuck key
                 if (!self.suppress_xim_result) {
-                    const result = self.processKeycode(self.pending_xim_keycode);
+                    const result = self.processKeycode(self.pending_xim_keycode, self.pending_xim_mods);
                     if (result != null) return result;
                 }
                 self.suppress_xim_result = false;
@@ -794,7 +798,7 @@ pub const X11Backend = struct {
             if (self.suppress_xim_result) {
                 self.suppress_xim_result = false;
             } else {
-                return self.processKeycode(self.forwarded_keycode);
+                return self.processKeycode(self.forwarded_keycode, self.forwarded_mods);
             }
         }
 
@@ -828,7 +832,7 @@ pub const X11Backend = struct {
                     if (self.suppress_xim_result) {
                         self.suppress_xim_result = false;
                     } else {
-                        return self.processKeycode(self.forwarded_keycode);
+                        return self.processKeycode(self.forwarded_keycode, self.forwarded_mods);
                     }
                 }
                 continue; // XIM consumed event but produced nothing, try next
@@ -886,6 +890,7 @@ pub const X11Backend = struct {
 
                             // Save pending key for fallback if IM doesn't respond
                             self.pending_xim_keycode = key.*.detail;
+                            self.pending_xim_mods = xcbStateToMods(key.*.state);
                             self.has_pending_xim = true;
                             self.xim_pending_ns = std.time.nanoTimestamp();
                             _ = c.xcb_xim_forward_event(xim, self.xic, key);
@@ -901,7 +906,7 @@ pub const X11Backend = struct {
                             if (self.has_forwarded_key) {
                                 self.has_forwarded_key = false;
                                 if (!self.suppress_xim_result) {
-                                    return self.processKeycode(self.forwarded_keycode);
+                                    return self.processKeycode(self.forwarded_keycode, self.forwarded_mods);
                                 }
                                 self.suppress_xim_result = false;
                                 return null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -428,8 +428,15 @@ fn handleBackendEvent(
         .paste => |paste_ev| {
             const text = paste_ev.slice();
             if (text.len > 0) {
+                // Wrap paste in bracketed paste sequences if application enabled DECSET 2004
+                if (term.bracketed_paste) {
+                    if (!ptyBufferedWrite(pty_ptr, "\x1b[200~", write_buf, write_pending, evloop_fd)) return false;
+                }
                 if (!ptyBufferedWrite(pty_ptr, text, write_buf, write_pending, evloop_fd)) {
                     return false;
+                }
+                if (term.bracketed_paste) {
+                    if (!ptyBufferedWrite(pty_ptr, "\x1b[201~", write_buf, write_pending, evloop_fd)) return false;
                 }
             }
         },

--- a/src/term.zig
+++ b/src/term.zig
@@ -561,20 +561,46 @@ pub const Term = struct {
             if (self.alt_ul_color_rgb) |a| self.allocator.free(a);
             if (self.alt_hyperlink_ids) |a| self.allocator.free(a);
 
+            // Initialize new alt buffers then copy existing content
             if (new_alt_cells) |nac| @memset(nac, Cell{});
+            if (new_alt_row_map) |narm| for (0..new_rows) |i| { narm[i] = @intCast(i); };
+            if (new_alt_fg) |nfg| @memset(nfg, null);
+            if (new_alt_bg) |nbg| @memset(nbg, null);
+            if (new_alt_ul) |nul| @memset(nul, null);
+            if (new_alt_hl) |nhl| @memset(nhl, 0);
+
+            // Copy existing alt buffer content (preserve hidden screen on resize)
+            if (self.alt_cells) |old_cells| {
+                if (new_alt_cells) |nac| {
+                    const alt_copy_cols: usize = @min(self.cols, new_cols);
+                    const alt_copy_rows: usize = @min(self.rows, new_rows);
+                    for (0..alt_copy_rows) |ay| {
+                        const old_rm = if (self.alt_row_map) |arm| arm[ay] else @as(u32, @intCast(ay));
+                        const old_start = @as(usize, old_rm) * @as(usize, self.cols);
+                        const new_start = ay * @as(usize, new_cols);
+                        @memcpy(nac[new_start .. new_start + alt_copy_cols], old_cells[old_start .. old_start + alt_copy_cols]);
+                        if (new_alt_fg) |nfg| if (self.alt_fg_rgb) |ofg| {
+                            @memcpy(nfg[new_start .. new_start + alt_copy_cols], ofg[old_start .. old_start + alt_copy_cols]);
+                        };
+                        if (new_alt_bg) |nbg| if (self.alt_bg_rgb) |obg| {
+                            @memcpy(nbg[new_start .. new_start + alt_copy_cols], obg[old_start .. old_start + alt_copy_cols]);
+                        };
+                        if (new_alt_ul) |nul| if (self.alt_ul_color_rgb) |oul| {
+                            @memcpy(nul[new_start .. new_start + alt_copy_cols], oul[old_start .. old_start + alt_copy_cols]);
+                        };
+                        if (new_alt_hl) |nhl| if (self.alt_hyperlink_ids) |ohl| {
+                            @memcpy(nhl[new_start .. new_start + alt_copy_cols], ohl[old_start .. old_start + alt_copy_cols]);
+                        };
+                    }
+                }
+            }
+
             self.alt_cells = new_alt_cells;
-            if (new_alt_row_map) |narm| for (0..new_rows) |i| {
-                narm[i] = @intCast(i);
-            };
             self.alt_row_map = new_alt_row_map;
             self.alt_dirty = new_alt_dirty;
-            if (new_alt_fg) |nfg| @memset(nfg, null);
             self.alt_fg_rgb = new_alt_fg;
-            if (new_alt_bg) |nbg| @memset(nbg, null);
             self.alt_bg_rgb = new_alt_bg;
-            if (new_alt_ul) |nul| @memset(nul, null);
             self.alt_ul_color_rgb = new_alt_ul;
-            if (new_alt_hl) |nhl| @memset(nhl, 0);
             self.alt_hyperlink_ids = new_alt_hl;
         }
     }

--- a/src/term.zig
+++ b/src/term.zig
@@ -552,16 +552,7 @@ pub const Term = struct {
             errdefer if (new_alt_ul) |naul| self.allocator.free(naul);
             const new_alt_hl = if (self.alt_hyperlink_ids != null) try self.allocator.alloc(u16, new_total) else null;
 
-            // All allocations succeeded — now free old and swap
-            if (self.alt_cells) |alt| self.allocator.free(alt);
-            if (self.alt_row_map) |arm| self.allocator.free(arm);
-            if (self.alt_dirty) |*ad| ad.deinit();
-            if (self.alt_fg_rgb) |a| self.allocator.free(a);
-            if (self.alt_bg_rgb) |a| self.allocator.free(a);
-            if (self.alt_ul_color_rgb) |a| self.allocator.free(a);
-            if (self.alt_hyperlink_ids) |a| self.allocator.free(a);
-
-            // Initialize new alt buffers then copy existing content
+            // Initialize new alt buffers then copy existing content BEFORE freeing old
             if (new_alt_cells) |nac| @memset(nac, Cell{});
             if (new_alt_row_map) |narm| for (0..new_rows) |i| { narm[i] = @intCast(i); };
             if (new_alt_fg) |nfg| @memset(nfg, null);
@@ -569,14 +560,17 @@ pub const Term = struct {
             if (new_alt_ul) |nul| @memset(nul, null);
             if (new_alt_hl) |nhl| @memset(nhl, 0);
 
-            // Copy existing alt buffer content (preserve hidden screen on resize)
+            // Copy content from old alt buffers using OLD dimensions (cols/rows already updated)
+            // old_cols/old_rows derived from old alt buffer sizes
             if (self.alt_cells) |old_cells| {
                 if (new_alt_cells) |nac| {
-                    const alt_copy_cols: usize = @min(self.cols, new_cols);
-                    const alt_copy_rows: usize = @min(self.rows, new_rows);
+                    const old_alt_cols = old_cells.len / (if (self.alt_row_map) |arm| arm.len else new_rows);
+                    const old_alt_rows = if (self.alt_row_map) |arm| arm.len else new_rows;
+                    const alt_copy_cols: usize = @min(old_alt_cols, new_cols);
+                    const alt_copy_rows: usize = @min(old_alt_rows, new_rows);
                     for (0..alt_copy_rows) |ay| {
                         const old_rm = if (self.alt_row_map) |arm| arm[ay] else @as(u32, @intCast(ay));
-                        const old_start = @as(usize, old_rm) * @as(usize, self.cols);
+                        const old_start = @as(usize, old_rm) * old_alt_cols;
                         const new_start = ay * @as(usize, new_cols);
                         @memcpy(nac[new_start .. new_start + alt_copy_cols], old_cells[old_start .. old_start + alt_copy_cols]);
                         if (new_alt_fg) |nfg| if (self.alt_fg_rgb) |ofg| {
@@ -594,6 +588,15 @@ pub const Term = struct {
                     }
                 }
             }
+
+            // Now free old buffers
+            if (self.alt_cells) |alt| self.allocator.free(alt);
+            if (self.alt_row_map) |arm| self.allocator.free(arm);
+            if (self.alt_dirty) |*ad| ad.deinit();
+            if (self.alt_fg_rgb) |a| self.allocator.free(a);
+            if (self.alt_bg_rgb) |a| self.allocator.free(a);
+            if (self.alt_ul_color_rgb) |a| self.allocator.free(a);
+            if (self.alt_hyperlink_ids) |a| self.allocator.free(a);
 
             self.alt_cells = new_alt_cells;
             self.alt_row_map = new_alt_row_map;

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -1246,10 +1246,16 @@ fn handleCsi(csi: CsiAction, term: *Term) void {
             term.cursor_x = @min(@as(u32, @intCast(col)), term.cols -| 1);
             term.wrap_next = false;
         },
-        'H', 'f' => { // CUP — cursor position (1-indexed params)
+        'H', 'f' => { // CUP/HVP — cursor position (1-indexed params, DECOM-aware)
             const row = if (pc > 0 and p[0] > 0) p[0] - 1 else 0;
             const col = if (pc > 1 and p[1] > 0) p[1] - 1 else 0;
-            term.moveCursorTo(@intCast(col), @intCast(row));
+            if (term.origin_mode) {
+                // DECOM: row is relative to scroll region top, clamped to region
+                const abs_row = term.scroll_top + @min(@as(u32, @intCast(row)), term.scroll_bottom - term.scroll_top);
+                term.moveCursorTo(@intCast(col), abs_row);
+            } else {
+                term.moveCursorTo(@intCast(col), @intCast(row));
+            }
         },
         'J' => { // ED / DECSED — erase display
             const mode: u8 = if (pc > 0) @intCast(p[0]) else 0;


### PR DESCRIPTION
## **User description**
## Summary
- **Bracketed paste**: Wrap paste data in `\e[200~`/`\e[201~` when DECSET 2004 is active
- **Resize hidden buffer**: Preserve hidden screen content during resize (fixes vim exit → lost shell)
- **DECOM origin mode**: CUP/HVP now addresses relative to scroll region when origin mode is set
- **fbdev pixel format**: Reject non-32bpp framebuffers at init instead of corrupting memory
- **Wayland primary selection**: Use correct opcode (0 vs 1) for primary selection receive
- **Wayland wire bounds**: Add bounds checking to protocol decoders to prevent OOB on malformed messages
- **XIM modifier preservation**: Preserve key modifiers through IME fallback path (fixes Alt+Left degradation)

## Test plan
- [ ] `zig build test` パス確認
- [ ] neovimでペースト → bracketed paste sequenceが送られることを確認
- [ ] vim起動中にリサイズ → vim終了後にシェル画面が保持されていることを確認
- [ ] Shift+Insert でprimary selection pasteが動作すること（Wayland環境）
- [ ] fcitx5有効時にAlt+Left/Alt+fが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix paste handling, cursor placement, and screen resizing in terminal sessions**

### What Changed
- Pasted text now follows bracketed paste mode when the app enables it, so paste is treated as paste instead of typed input.
- Resizing an app on the alternate screen keeps its hidden contents, which prevents losing the shell screen after leaving programs like vim.
- Cursor positioning now respects origin mode, so terminal apps place the cursor within the current scroll region as expected.
- Shift+Insert and Ctrl+Shift+V now use the correct Wayland paste path, and IME fallback keeps modifier keys like Alt and Shift with the original key.
- Startup now rejects unsupported framebuffer formats instead of drawing with the wrong pixel layout.
- Malformed Wayland messages are handled safely instead of causing crashes.

### Impact
`✅ Safer paste in terminal apps`
`✅ Fewer lost screens after resize`
`✅ Correct cursor movement in full-screen programs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブラケット付きペースト機能を追加しました
  * スクロール領域を考慮したカーソル位置決めを実装しました
  * キーボード修飾子の状態トラッキングを強化しました

* **バグ修正**
  * ペースト操作のハンドリングを改善しました
  * メモリアクセスの安全性チェックを追加しました
  * 画面切り替え時にバッファの内容を保持するよう修正しました
  * フレームバッファのフォーマット検証を強化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->