### PR TITLE
Fix X11 XIM input lag and Japanese double-input

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,6 +27,7 @@ pub fn build(b: *std.Build) void {
     options.addOption(u32, "max_fps", max_fps_opt);
     options.addOption(u32, "pty_buf_kb", pty_buf_kb_opt);
     options.addOption([:0]const u8, "shell", shell_opt);
+    options.addOption([:0]const u8, "version", b.allocator.dupeZ(u8, "0.5.7") catch @panic("OOM"));
 
     const config_mod = b.createModule(.{
         .root_source_file = b.path("config.zig"),

--- a/config.zig
+++ b/config.zig
@@ -40,3 +40,4 @@ pub const frame_min_ns: u64 = if (max_fps == 0) 0 else 1_000_000_000 / max_fps;
 pub const pty_buf_size: u32 = build_options.pty_buf_kb * 1024;
 
 pub const shell: [:0]const u8 = std.mem.span(@as([*:0]const u8, build_options.shell));
+pub const version: [:0]const u8 = std.mem.span(@as([*:0]const u8, build_options.version));

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -780,6 +780,10 @@ pub const X11Backend = struct {
                 self.has_pending_xim = false;
                 // Fall back to local XKB processing for the stuck key
                 if (!self.suppress_xim_result) {
+                    // Suppress the late XIM response that may arrive after
+                    // this timeout — without this, both the fallback ASCII
+                    // and the eventual IME commit would be emitted.
+                    self.suppress_xim_result = true;
                     const result = self.processKeycode(self.pending_xim_keycode, self.pending_xim_mods);
                     if (result != null) return result;
                 }

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -171,6 +171,7 @@ pub const X11Backend = struct {
 
         // 5. Set WM_CLASS and WM_NAME (skip in embedded mode)
         if (embed_window == 0) {
+            const wm_name = "zt " ++ config.version;
             _ = c.xcb_change_property(
                 connection,
                 c.XCB_PROP_MODE_REPLACE,
@@ -178,8 +179,8 @@ pub const X11Backend = struct {
                 c.XCB_ATOM_WM_NAME,
                 c.XCB_ATOM_STRING,
                 8,
-                2,
-                "zt",
+                wm_name.len,
+                wm_name,
             );
             // WM_CLASS: "zt\0zt\0" (instance\0class\0)
             _ = c.xcb_change_property(

--- a/src/main.zig
+++ b/src/main.zig
@@ -899,10 +899,14 @@ pub fn main() !void {
         prev_cursor_x = term.cursor_x;
         prev_cursor_y = term.cursor_y;
 
-        // Flush Wayland protocol responses (pong, ack_configure) every iteration,
-        // even when we skip rendering. Without this, the compositor marks us
-        // "not responding" because pong sits in the send buffer.
-        if (config.backend == .wayland) backend.flush();
+        // Flush protocol responses every iteration, even when we skip rendering.
+        // Wayland: without this, the compositor marks us "not responding"
+        //          because pong sits in the send buffer.
+        // X11:     without this, XIM forward_event messages sit in the XCB
+        //          output buffer until the next render, causing 0-500ms input
+        //          latency and XIM timeout fallback that leaks raw ASCII
+        //          alongside committed IME text.
+        if (config.backend == .wayland or config.backend == .x11) backend.flush();
 
         // Render dirty cells — skip entirely if nothing changed
         if (!term.hasDirty()) continue;


### PR DESCRIPTION
## **User description**
## Summary
- Flush XCB output buffer every event-loop iteration for X11 (matching Wayland behavior), so `xcb_xim_forward_event` messages reach the IM server immediately instead of waiting up to 500ms for the next render cycle
- Suppress late XIM responses after timeout fallback fires, preventing both raw ASCII and IME commit from being emitted for a single keypress

## Root Cause
The X11 backend only called `xcb_flush` inside the render block (after `present()`). When no terminal cells were dirty (idle typing, no PTY output), the render was skipped and XIM protocol messages sat in the XCB send buffer. The cursor-blink timer (500ms) was the only incidental flush trigger, racing with the XIM timeout threshold.

## Test plan
- [ ] Build with `-Dbackend=x11` and verify compilation
- [ ] Type Japanese via fcitx5/mozc in romaji mode — no extra alphabet characters
- [ ] Verify input responsiveness in idle sessions (no background output)
- [ ] Shift+Space IME toggle still works without leaking space character

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix X11 Japanese input lag and duplicate characters**

### What Changed
- X11 now sends IME input requests immediately on every loop, even when nothing is being redrawn, so typing no longer waits for the next render cycle.
- When the IM server responds too late after a timeout fallback, the app now ignores that late IME result instead of showing both the fallback key and the committed Japanese text.

### Impact
`✅ Faster Japanese input on X11`
`✅ Fewer duplicate characters while typing with an IME`
`✅ Fewer 500ms input delays in idle sessions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ウィンドウ名にアプリのバージョン情報を含めるようになりました。
* **バグ修正**
  * X11環境でのIME（XIM）による遅延到着の重複出力を抑制しました。
  * X11でのキー入力応答性を改善し、入力遅延を低減しました。
* **その他**
  * ビルド設定にバージョン項目を追加し、設定として公開しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->