### PR TITLE
Fix Wayland segfault: use-after-munmap, socket path, null guards

### DIFF
--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -262,7 +262,7 @@ pub const WaylandBackend = struct {
                 const payload = conn.consumeEvent(header.size);
                 if (header.object_id == sync_callback_id and header.opcode == core.WL_CALLBACK_EVENT_DONE) {
                     sync_done = true;
-                } else if (header.object_id == globals.shm and header.opcode == core.WL_SHM_EVENT_FORMAT) {
+                } else if (globals.shm != 0 and header.object_id == globals.shm and header.opcode == core.WL_SHM_EVENT_FORMAT) {
                     var pos: usize = 0;
                     const format = wire.getUint(payload, &pos);
                     if (format == core.SHM_FORMAT_ARGB8888) {
@@ -332,7 +332,7 @@ pub const WaylandBackend = struct {
                     const serial = wire.getUint(payload, &pos);
                     try xdg_shell.ackConfigure(&conn, xdg_surface_id, serial);
                     got_configure = true;
-                } else if (header.object_id == globals.xdg_wm_base and header.opcode == xdg_shell.XDG_WM_BASE_EVENT_PING) {
+                } else if (globals.xdg_wm_base != 0 and header.object_id == globals.xdg_wm_base and header.opcode == xdg_shell.XDG_WM_BASE_EVENT_PING) {
                     var pos: usize = 0;
                     const serial = wire.getUint(payload, &pos);
                     try xdg_shell.pong(&conn, globals.xdg_wm_base, serial);
@@ -479,7 +479,7 @@ pub const WaylandBackend = struct {
                     // wl_display.delete_id later, and dispatchEvent handles it.
                     // Releasing here causes double-free on the ID free list,
                     // leading to two objects sharing the same ID → protocol error.
-                } else if (header.object_id == self.globals.xdg_wm_base and header.opcode == xdg_shell.XDG_WM_BASE_EVENT_PING) {
+                } else if (self.globals.xdg_wm_base != 0 and header.object_id == self.globals.xdg_wm_base and header.opcode == xdg_shell.XDG_WM_BASE_EVENT_PING) {
                     var pos: usize = 0;
                     const serial = wire.getUint(payload, &pos);
                     xdg_shell.pong(&self.conn, self.globals.xdg_wm_base, serial) catch {};

--- a/src/backend/wayland/core.zig
+++ b/src/backend/wayland/core.zig
@@ -341,8 +341,8 @@ pub const ShmBuffer = struct {
         // 2. Grow pool if needed
         if (new_total_size > self.pool_capacity) {
             try posix.ftruncate(self.fd, @intCast(new_total_size));
-            posix.munmap(self.data);
-            self.data = try posix.mmap(
+            // mmap new region BEFORE munmap to avoid dangling pointer on failure
+            const new_data = try posix.mmap(
                 null,
                 new_total_size,
                 posix.PROT.READ | posix.PROT.WRITE,
@@ -350,6 +350,8 @@ pub const ShmBuffer = struct {
                 self.fd,
                 0,
             );
+            posix.munmap(self.data);
+            self.data = new_data;
             var payload: [4]u8 = undefined;
             var pos: usize = 0;
             wire.putInt(&payload, &pos, @intCast(new_total_size));

--- a/src/backend/wayland/wire.zig
+++ b/src/backend/wayland/wire.zig
@@ -178,12 +178,17 @@ pub const Connection = struct {
 
     /// Connect to the Wayland compositor's UNIX socket.
     /// Reads $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY (defaults to "wayland-0").
+    /// If WAYLAND_DISPLAY is an absolute path, it is used directly (per Wayland spec).
     pub fn connect() !Connection {
-        const runtime_dir = std.posix.getenv("XDG_RUNTIME_DIR") orelse return error.NoXdgRuntimeDir;
         const display = std.posix.getenv("WAYLAND_DISPLAY") orelse "wayland-0";
 
         var path_buf: [256]u8 = undefined;
-        const path = std.fmt.bufPrintZ(&path_buf, "{s}/{s}", .{ runtime_dir, display }) catch return error.PathTooLong;
+        const path = if (display.len > 0 and display[0] == '/')
+            std.fmt.bufPrintZ(&path_buf, "{s}", .{display}) catch return error.PathTooLong
+        else blk: {
+            const runtime_dir = std.posix.getenv("XDG_RUNTIME_DIR") orelse return error.NoXdgRuntimeDir;
+            break :blk std.fmt.bufPrintZ(&path_buf, "{s}/{s}", .{ runtime_dir, display }) catch return error.PathTooLong;
+        };
 
         const sock_fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK, 0);
         errdefer posix.close(sock_fd);
@@ -391,7 +396,10 @@ pub const Connection = struct {
         const start = self.recv_consumed + 8;
         const end = self.recv_consumed + size;
         const payload = self.recv_buf[start..end];
-        self.recv_consumed += size;
+        // Align to 4-byte boundary (Wayland wire protocol requirement).
+        // Sizes should always be 4-aligned per spec, but guard against
+        // malformed messages to prevent misaligned pointer in nextEvent.
+        self.recv_consumed += alignUp(size, 4);
         return payload;
     }
 

--- a/src/backend/wayland/wire.zig
+++ b/src/backend/wayland/wire.zig
@@ -386,7 +386,9 @@ pub const Connection = struct {
         const words: *const [2]u32 = @alignCast(@ptrCast(self.recv_buf[self.recv_consumed..].ptr));
         const hdr = decodeHeader(words);
         if (hdr.size < 8) return null; // malformed
-        if (avail < hdr.size) return null; // incomplete
+        // Check aligned size so consumeEvent can safely advance to next
+        // 4-byte boundary without overrunning the receive buffer.
+        if (avail < alignUp(hdr.size, 4)) return null; // incomplete
         return hdr;
     }
 


### PR DESCRIPTION
## **User description**
## Summary
- **Fix use-after-munmap segfault in `resizeBuffers`**: reorder mmap/munmap so a failed mmap doesn't leave a dangling pointer — the most likely cause of "segfault on Wayland" during window resize
- **Support absolute `WAYLAND_DISPLAY` paths** per Wayland spec — compositors like Sway can set this to an absolute path, which previously caused connection failure
- **Add 4-byte alignment guard in `consumeEvent`** to prevent misaligned pointer dereference from malformed wire messages
- **Add null guards on `globals.shm` and `globals.xdg_wm_base`** in init event loops, matching the defensive pattern already used for `globals.seat`

## Test plan
- [x] `zig build -Dbackend=wayland` compiles cleanly
- [x] `zig build test -Dbackend=wayland` passes
- [ ] Manual test: run on Wayland compositor (Sway, Hyprland, etc.)
- [ ] Manual test: resize window rapidly to exercise resizeBuffers path
- [ ] Manual test: verify with `WAYLAND_DISPLAY=/absolute/path` if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix Wayland connection, resize, and event handling crashes**

### What Changed
- Wayland now accepts an absolute `WAYLAND_DISPLAY` path directly, which lets it connect on compositors that set a full socket path.
- Window resize keeps the old buffer alive until the new memory mapping succeeds, avoiding a crash if resize allocation fails.
- Malformed Wayland messages no longer leave event parsing misaligned, reducing the chance of a crash on bad input.
- Startup and event handling now skip missing Wayland globals safely instead of trying to use them.

### Impact
`✅ Fewer Wayland startup failures`
`✅ Fewer resize-time crashes`
`✅ Fewer crashes from malformed Wayland messages`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
