### PR TITLE
Fix XIM CapsLock handling and romaji composition timeout

### DIFF
--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -785,6 +785,10 @@ pub const X11Backend = struct {
             if (now - self.xim_pending_ns > 5_000_000_000) {
                 self.has_pending_xim = false;
                 self.suppress_xim_result = false;
+                // Mark XIM as disconnected so subsequent keys fall back to
+                // local XKB instead of being forwarded into a dead IM server.
+                self.xim_connected = false;
+                self.xic = 0;
             }
         }
 
@@ -856,11 +860,19 @@ pub const X11Backend = struct {
 
                 // Sync XKB modifier state from X server. Using update_mask (not
                 // update_key) avoids state desync when XIM consumes key releases.
-                // Decompose X11 state bits: CapsLock (LockMask=0x02) and NumLock
-                // (Mod2Mask=0x10) are lock modifiers, not depressed modifiers.
+                // Decompose X11 state bits: CapsLock (LockMask=0x02) is always a
+                // lock modifier. NumLock's real modifier bit is resolved dynamically
+                // via xkb_keymap_mod_get_index (typically Mod2=0x10 but not guaranteed).
                 if (self.xkb_state) |state| {
                     const x_state: u32 = key.*.state;
-                    const lock_bits: u32 = x_state & (0x02 | 0x10); // LockMask | Mod2Mask
+                    var lock_mask: u32 = 0x02; // LockMask (CapsLock) is always bit 1
+                    if (self.xkb_keymap) |km| {
+                        const num_idx = c.xkb_keymap_mod_get_index(km, "Mod2");
+                        if (num_idx != c.XKB_MOD_INVALID) {
+                            lock_mask |= @as(u32, 1) << @intCast(num_idx);
+                        }
+                    }
+                    const lock_bits: u32 = x_state & lock_mask;
                     _ = c.xkb_state_update_mask(
                         state,
                         x_state & ~lock_bits, // depressed (Shift, Ctrl, Alt, etc.)

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -774,20 +774,16 @@ pub const X11Backend = struct {
             return .close;
         }
 
-        // XIM timeout: if IM server hasn't responded within 500ms, fall back to local XKB
+        // XIM timeout: if IM server hasn't responded within 5 seconds,
+        // assume it crashed and clear pending state. Do NOT emit a fallback
+        // character — during Japanese romaji composition, consonants sit in
+        // the preedit buffer for extended periods waiting for the next key
+        // to disambiguate (e.g., "n" waits to see if "a" follows for "な"
+        // or "n" follows for "ん"). Emitting a fallback would leak raw ASCII.
         if (self.has_pending_xim) {
             const now = std.time.nanoTimestamp();
-            if (now - self.xim_pending_ns > 500_000_000) {
+            if (now - self.xim_pending_ns > 5_000_000_000) {
                 self.has_pending_xim = false;
-                // Fall back to local XKB processing for the stuck key
-                if (!self.suppress_xim_result) {
-                    // Suppress the late XIM response that may arrive after
-                    // this timeout — without this, both the fallback ASCII
-                    // and the eventual IME commit would be emitted.
-                    self.suppress_xim_result = true;
-                    const result = self.processKeycode(self.pending_xim_keycode, self.pending_xim_mods);
-                    if (result != null) return result;
-                }
                 self.suppress_xim_result = false;
             }
         }
@@ -858,15 +854,18 @@ pub const X11Backend = struct {
                 const evdev_keycode = key.*.detail -| 8;
                 const xcb_keycode: u32 = key.*.detail;
 
-                // Sync XKB modifier state from X server so Shift/CapsLock are
-                // reflected in xkb_state_key_get_utf8. Using update_mask (not
+                // Sync XKB modifier state from X server. Using update_mask (not
                 // update_key) avoids state desync when XIM consumes key releases.
+                // Decompose X11 state bits: CapsLock (LockMask=0x02) and NumLock
+                // (Mod2Mask=0x10) are lock modifiers, not depressed modifiers.
                 if (self.xkb_state) |state| {
+                    const x_state: u32 = key.*.state;
+                    const lock_bits: u32 = x_state & (0x02 | 0x10); // LockMask | Mod2Mask
                     _ = c.xkb_state_update_mask(
                         state,
-                        key.*.state, // depressed (base) modifiers from X server
+                        x_state & ~lock_bits, // depressed (Shift, Ctrl, Alt, etc.)
                         0, // latched
-                        0, // locked
+                        lock_bits, // locked (CapsLock, NumLock)
                         0, 0, 0, // group: base, latched, locked
                     );
                 }


### PR DESCRIPTION
## **User description**
## Summary
- Fix `xkb_state_update_mask` to correctly decompose X11 modifier state — CapsLock and NumLock are now passed as locked modifiers instead of depressed
- Remove XIM timeout fallback character emission — consonants in romaji preedit (e.g., "n" waiting for disambiguation) no longer leak as raw ASCII after 500ms
- Increase XIM timeout from 500ms to 5s as a crash-only safety net

## Root Cause
1. **CapsLock/NumLock**: `key.*.state` was passed entirely as `depressed_mods` with `locked=0`, so xkbcommon never saw lock states
2. **Romaji leak**: The 500ms timeout called `processKeycode()` which emitted raw ASCII for keys still held in the IME preedit buffer (e.g., typing "asdf" produced "fあｓｄｆ" instead of "あｓｄｆ")

## Test plan
- [ ] Type Japanese via fcitx5-mozc romaji: "asdf" → "あｓｄｆ" with no extra characters
- [ ] Fast typing "nihongo" → "にほんご" cleanly
- [ ] CapsLock produces uppercase when engaged
- [ ] NumLock works for numpad keys
- [ ] IME toggle (Shift+Space) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix Caps Lock, Num Lock, and Japanese romaji input on X11**

### What Changed
- Caps Lock and Num Lock are now recognized correctly during typing, so uppercase and numpad input work as expected.
- Japanese romaji input no longer falls back to raw ASCII after a short pause, which prevents extra characters from appearing while composing text.
- The IME timeout now waits longer before giving up, so slow or complex romaji composition is less likely to be interrupted.

### Impact
`✅ Correct Caps Lock typing`
`✅ Working Num Lock input`
`✅ Fewer stray characters in Japanese input`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * X11システムでの入力メソッドのタイムアウト処理を改善し、応答性を向上させました
  * キーボード修飾キー（CapsLock、NumLock）の状態同期をより正確に処理するよう調整しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->