### PR TITLE
Fix 7 UX bugs: title, paste, TrueColor, alt screen, XKB, response buf, BEL

### DIFF
--- a/src/backend/macos.zig
+++ b/src/backend/macos.zig
@@ -221,7 +221,7 @@ pub const Event = union(enum) {
 };
 
 pub const PasteEvent = struct {
-    data: [65536]u8 = undefined,
+    data: [16384]u8 = undefined,
     len: u32 = 0,
 
     pub fn slice(self: *const PasteEvent) []const u8 {

--- a/src/backend/macos.zig
+++ b/src/backend/macos.zig
@@ -221,7 +221,7 @@ pub const Event = union(enum) {
 };
 
 pub const PasteEvent = struct {
-    data: [4096]u8 = undefined,
+    data: [65536]u8 = undefined,
     len: u32 = 0,
 
     pub fn slice(self: *const PasteEvent) []const u8 {

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -632,6 +632,11 @@ pub const WaylandBackend = struct {
         self.conn.flush() catch {};
     }
 
+    /// Update the Wayland window title via xdg_toplevel.set_title.
+    pub fn updateTitle(self: *Self, title: []const u8) void {
+        xdg_shell.setTitle(&self.conn, self.toplevel_id, title) catch {};
+    }
+
     // ========================================================================
     // Resize
     // ========================================================================

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -28,7 +28,7 @@ pub const Event = union(enum) {
 };
 
 pub const PasteEvent = struct {
-    data: [65536]u8 = undefined,
+    data: [16384]u8 = undefined,
     len: u32 = 0,
 
     pub fn slice(self: *const PasteEvent) []const u8 {
@@ -634,7 +634,9 @@ pub const WaylandBackend = struct {
 
     /// Update the Wayland window title via xdg_toplevel.set_title.
     pub fn updateTitle(self: *Self, title: []const u8) void {
-        xdg_shell.setTitle(&self.conn, self.toplevel_id, title) catch {};
+        // Clamp to 240 bytes — putString needs 4-byte length + string + NUL + padding
+        const clamped = title[0..@min(title.len, 240)];
+        xdg_shell.setTitle(&self.conn, self.toplevel_id, clamped) catch {};
     }
 
     // ========================================================================

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -634,8 +634,8 @@ pub const WaylandBackend = struct {
 
     /// Update the Wayland window title via xdg_toplevel.set_title.
     pub fn updateTitle(self: *Self, title: []const u8) void {
-        // Clamp to 240 bytes — putString needs 4-byte length + string + NUL + padding
-        const clamped = title[0..@min(title.len, 240)];
+        // Clamp to 251 bytes — putString uses 4 (len) + N + 1 (NUL) + padding in 256-byte payload
+        const clamped = title[0..@min(title.len, 251)];
         xdg_shell.setTitle(&self.conn, self.toplevel_id, clamped) catch {};
     }
 

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -28,7 +28,7 @@ pub const Event = union(enum) {
 };
 
 pub const PasteEvent = struct {
-    data: [4096]u8 = undefined,
+    data: [65536]u8 = undefined,
     len: u32 = 0,
 
     pub fn slice(self: *const PasteEvent) []const u8 {

--- a/src/backend/wayland/clipboard.zig
+++ b/src/backend/wayland/clipboard.zig
@@ -71,7 +71,7 @@ pub const ClipboardState = struct {
 
     // Paste pipe (async read)
     paste_pipe_fd: posix.fd_t = -1,
-    paste_buf: [4096]u8 = undefined,
+    paste_buf: [65536]u8 = undefined,
     paste_len: usize = 0,
 };
 

--- a/src/backend/wayland/clipboard.zig
+++ b/src/backend/wayland/clipboard.zig
@@ -71,7 +71,7 @@ pub const ClipboardState = struct {
 
     // Paste pipe (async read)
     paste_pipe_fd: posix.fd_t = -1,
-    paste_buf: [65536]u8 = undefined,
+    paste_buf: [16384]u8 = undefined,
     paste_len: usize = 0,
 };
 

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -1132,8 +1132,28 @@ pub const X11Backend = struct {
                 continue;
             },
             c.XCB_DESTROY_NOTIFY => return .close,
-            c.XCB_FOCUS_IN => return .focus_in,
-            c.XCB_FOCUS_OUT => return .focus_out,
+            c.XCB_FOCUS_IN => {
+                // Re-establish XIM IC focus so the IM server accepts forwarded keys
+                if (self.xim) |xim| {
+                    if (self.xim_connected and self.xic != 0) {
+                        _ = c.xcb_xim_set_ic_focus(xim, self.xic);
+                    }
+                }
+                return .focus_in;
+            },
+            c.XCB_FOCUS_OUT => {
+                // Clear stale XIM pending state — the IM server will not
+                // respond to a key forwarded before focus was lost.
+                self.has_pending_xim = false;
+                self.suppress_xim_result = false;
+                // Notify IM server that IC lost focus
+                if (self.xim) |xim| {
+                    if (self.xim_connected and self.xic != 0) {
+                        _ = c.xcb_xim_unset_ic_focus(xim, self.xic);
+                    }
+                }
+                return .focus_out;
+            },
             else => continue, // Skip unhandled events (ReparentNotify, MapNotify, etc.)
         }
         } // while (true)

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -635,6 +635,11 @@ pub const X11Backend = struct {
         return 4;
     }
 
+    /// Ring the X11 bell (urgency hint).
+    pub fn bell(self: *Self) void {
+        _ = c.xcb_bell(self.connection, 0);
+    }
+
     /// Update the X11 window title (WM_NAME property).
     pub fn updateTitle(self: *Self, title: []const u8) void {
         _ = c.xcb_change_property(

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -1004,12 +1004,23 @@ pub const X11Backend = struct {
                 } };
             },
             c.XCB_KEY_RELEASE => {
+                // Update XKB modifier state so lock/depressed bits stay in sync
+                // after modifier keys are released. Don't return an event —
+                // handleBackendEvent ignores key releases anyway, and returning
+                // one wastes an epoll wakeup per keystroke.
                 const key: *c.xcb_key_release_event_t = @ptrCast(@alignCast(event));
-                return .{ .key = .{
-                    .keycode = key.*.detail -| 8,
-                    .pressed = false,
-                    .modifiers = xcbStateToMods(key.*.state),
-                } };
+                if (self.xkb_state) |state| {
+                    const x_state: u32 = key.*.state;
+                    const lock_bits: u32 = x_state & (0x02 | 0x10);
+                    _ = c.xkb_state_update_mask(
+                        state,
+                        x_state & ~lock_bits,
+                        0,
+                        lock_bits,
+                        0, 0, 0,
+                    );
+                }
+                continue;
             },
             c.XCB_CONFIGURE_NOTIFY => {
                 const cfg: *c.xcb_configure_notify_event_t = @ptrCast(@alignCast(event));

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -635,6 +635,20 @@ pub const X11Backend = struct {
         return 4;
     }
 
+    /// Update the X11 window title (WM_NAME property).
+    pub fn updateTitle(self: *Self, title: []const u8) void {
+        _ = c.xcb_change_property(
+            self.connection,
+            c.XCB_PROP_MODE_REPLACE,
+            self.window,
+            c.XCB_ATOM_WM_NAME,
+            c.XCB_ATOM_STRING,
+            8,
+            @intCast(title.len),
+            title.ptr,
+        );
+    }
+
     /// Update IME candidate window position to follow the terminal cursor.
     /// Uses set_ic_values with XNSpotLocation (standard XIM protocol).
     /// Only sends when position changes to avoid IME instability.

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -23,7 +23,7 @@ pub const Event = union(enum) {
 };
 
 pub const PasteEvent = struct {
-    data: [65536]u8 = undefined,
+    data: [16384]u8 = undefined,
     len: u32 = 0,
 
     pub fn slice(self: *const PasteEvent) []const u8 {
@@ -77,6 +77,7 @@ pub const X11Backend = struct {
     clipboard_atom: c.xcb_atom_t = 0,
     utf8_string_atom: c.xcb_atom_t = 0,
     zt_paste_atom: c.xcb_atom_t = 0, // property for receiving paste data
+    net_wm_name_atom: c.xcb_atom_t = 0,
     // XKB (keyboard layout)
     xkb_ctx: ?*c.xkb_context = null,
     xkb_keymap: ?*c.xkb_keymap = null,
@@ -201,6 +202,7 @@ pub const X11Backend = struct {
         const clipboard_cookie = c.xcb_intern_atom(connection, 0, 9, "CLIPBOARD");
         const utf8_cookie = c.xcb_intern_atom(connection, 0, 11, "UTF8_STRING");
         const paste_cookie = c.xcb_intern_atom(connection, 0, 8, "ZT_PASTE");
+        const net_wm_name_cookie = c.xcb_intern_atom(connection, 0, 12, "_NET_WM_NAME");
         const xembed_cookie = c.xcb_intern_atom(connection, 0, 7, "_XEMBED");
         const xembed_info_cookie = c.xcb_intern_atom(connection, 0, 12, "_XEMBED_INFO");
 
@@ -244,6 +246,11 @@ pub const X11Backend = struct {
         if (clipboard_reply) |r| clipboard_atom = r.*.atom;
         if (utf8_reply) |r| utf8_string_atom = r.*.atom;
         if (paste_reply) |r| zt_paste_atom = r.*.atom;
+
+        const net_wm_name_reply = c.xcb_intern_atom_reply(connection, net_wm_name_cookie, null);
+        defer if (net_wm_name_reply) |r| std.c.free(r);
+        var net_wm_name_atom: c.xcb_atom_t = 0;
+        if (net_wm_name_reply) |r| net_wm_name_atom = r.*.atom;
 
         const xembed_reply = c.xcb_intern_atom_reply(connection, xembed_cookie, null);
         defer if (xembed_reply) |r| std.c.free(r);
@@ -317,6 +324,7 @@ pub const X11Backend = struct {
             .clipboard_atom = clipboard_atom,
             .utf8_string_atom = utf8_string_atom,
             .zt_paste_atom = zt_paste_atom,
+            .net_wm_name_atom = net_wm_name_atom,
             .screen_id = screen_num,
             .embed_parent = embed_window,
             .xembed_atom = xembed_atom,
@@ -640,7 +648,7 @@ pub const X11Backend = struct {
         _ = c.xcb_bell(self.connection, 0);
     }
 
-    /// Update the X11 window title (WM_NAME property).
+    /// Update the X11 window title (WM_NAME + _NET_WM_NAME for UTF-8).
     pub fn updateTitle(self: *Self, title: []const u8) void {
         _ = c.xcb_change_property(
             self.connection,
@@ -652,6 +660,19 @@ pub const X11Backend = struct {
             @intCast(title.len),
             title.ptr,
         );
+        // Also set _NET_WM_NAME with UTF8_STRING for proper Unicode support
+        if (self.net_wm_name_atom != 0 and self.utf8_string_atom != 0) {
+            _ = c.xcb_change_property(
+                self.connection,
+                c.XCB_PROP_MODE_REPLACE,
+                self.window,
+                self.net_wm_name_atom,
+                self.utf8_string_atom,
+                8,
+                @intCast(title.len),
+                title.ptr,
+            );
+        }
     }
 
     /// Update IME candidate window position to follow the terminal cursor.
@@ -1009,21 +1030,12 @@ pub const X11Backend = struct {
                 } };
             },
             c.XCB_KEY_RELEASE => {
-                // Update XKB modifier state so lock/depressed bits stay in sync
-                // after modifier keys are released. Don't return an event —
-                // handleBackendEvent ignores key releases anyway, and returning
-                // one wastes an epoll wakeup per keystroke.
+                // Update XKB state on release so modifier tracking stays in sync.
+                // Use update_key(UP) instead of update_mask because the X11
+                // state field in a release event reflects the PRE-release state.
                 const key: *c.xcb_key_release_event_t = @ptrCast(@alignCast(event));
                 if (self.xkb_state) |state| {
-                    const x_state: u32 = key.*.state;
-                    const lock_bits: u32 = x_state & (0x02 | 0x10);
-                    _ = c.xkb_state_update_mask(
-                        state,
-                        x_state & ~lock_bits,
-                        0,
-                        lock_bits,
-                        0, 0, 0,
-                    );
+                    _ = c.xkb_state_update_key(state, key.*.detail, c.XKB_KEY_UP);
                 }
                 continue;
             },
@@ -1072,7 +1084,7 @@ pub const X11Backend = struct {
                     const len: u32 = @intCast(c.xcb_get_property_value_length(reply));
                     if (len > 0) {
                         const data: [*]const u8 = @ptrCast(c.xcb_get_property_value(reply));
-                        const clamped = @min(len, 65536);
+                        const clamped = @min(len, 16384);
                         @memcpy(self.paste_buf.data[0..clamped], data[0..clamped]);
                         self.paste_buf.len = clamped;
                         return .{ .paste = self.paste_buf };

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -23,7 +23,7 @@ pub const Event = union(enum) {
 };
 
 pub const PasteEvent = struct {
-    data: [4096]u8 = undefined,
+    data: [65536]u8 = undefined,
     len: u32 = 0,
 
     pub fn slice(self: *const PasteEvent) []const u8 {
@@ -1056,7 +1056,7 @@ pub const X11Backend = struct {
                     const len: u32 = @intCast(c.xcb_get_property_value_length(reply));
                     if (len > 0) {
                         const data: [*]const u8 = @ptrCast(c.xcb_get_property_value(reply));
-                        const clamped = @min(len, 4096);
+                        const clamped = @min(len, 65536);
                         @memcpy(self.paste_buf.data[0..clamped], data[0..clamped]);
                         self.paste_buf.len = clamped;
                         return .{ .paste = self.paste_buf };

--- a/src/main.zig
+++ b/src/main.zig
@@ -1016,6 +1016,14 @@ pub fn main() !void {
         last_render_ns = loop_now;
         bytes_since_render = 0;
 
+        // Handle BEL
+        if (term.bell_pending) {
+            term.bell_pending = false;
+            if (@hasDecl(Backend, "bell")) {
+                backend.bell();
+            }
+        }
+
         // Update window title if changed by OSC 0/2
         if (term.title_changed) {
             term.title_changed = false;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1028,7 +1028,17 @@ pub fn main() !void {
         if (term.title_changed) {
             term.title_changed = false;
             if (@hasDecl(Backend, "updateTitle")) {
-                backend.updateTitle(term.title[0..term.title_len]);
+                if (term.title_len > 0) {
+                    // Prefix with "zt — " so the version/app name stays visible
+                    var title_buf: [280]u8 = undefined;
+                    const prefix = "zt — ";
+                    @memcpy(title_buf[0..prefix.len], prefix);
+                    const tlen: usize = term.title_len;
+                    @memcpy(title_buf[prefix.len..][0..tlen], term.title[0..tlen]);
+                    backend.updateTitle(title_buf[0 .. prefix.len + tlen]);
+                } else {
+                    backend.updateTitle("zt " ++ config.version);
+                }
             }
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1031,7 +1031,7 @@ pub fn main() !void {
                 if (term.title_len > 0) {
                     // Prefix with "zt — " so the version/app name stays visible
                     var title_buf: [280]u8 = undefined;
-                    const prefix = "zt — ";
+                    const prefix = "zt " ++ config.version ++ " — ";
                     @memcpy(title_buf[0..prefix.len], prefix);
                     const tlen: usize = term.title_len;
                     @memcpy(title_buf[prefix.len..][0..tlen], term.title[0..tlen]);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1016,6 +1016,14 @@ pub fn main() !void {
         last_render_ns = loop_now;
         bytes_since_render = 0;
 
+        // Update window title if changed by OSC 0/2
+        if (term.title_changed) {
+            term.title_changed = false;
+            if (@hasDecl(Backend, "updateTitle")) {
+                backend.updateTitle(term.title[0..term.title_len]);
+            }
+        }
+
         // Update IME cursor position (X11 only)
         if (@hasDecl(Backend, "updateImeCursorPos")) {
             backend.updateImeCursorPos(

--- a/src/term.zig
+++ b/src/term.zig
@@ -193,6 +193,7 @@ pub const Term = struct {
     saved_fg_rgb: ?[3]u8 = null,
     saved_bg_rgb: ?[3]u8 = null,
     saved_ul_color_rgb: ?[3]u8 = null,
+    saved_charsets: [4]CharsetType = .{ .us_ascii, .us_ascii, .us_ascii, .us_ascii },
 
     pub fn init(allocator: Allocator, cols: u32, rows: u32) !Self {
         const total = @as(usize, cols) * @as(usize, rows);

--- a/src/term.zig
+++ b/src/term.zig
@@ -195,6 +195,21 @@ pub const Term = struct {
     saved_ul_color_rgb: ?[3]u8 = null,
     saved_charsets: [4]CharsetType = .{ .us_ascii, .us_ascii, .us_ascii, .us_ascii },
 
+    // Separate save area for ?1049 alt screen (must not collide with DECSC/DECRC)
+    alt_saved_cursor_x: u32 = 0,
+    alt_saved_cursor_y: u32 = 0,
+    alt_saved_scroll_top: u32 = 0,
+    alt_saved_scroll_bottom: u32 = 0,
+    alt_saved_wrap_next: bool = false,
+    alt_saved_attrs: Cell.Attrs = .{},
+    alt_saved_fg: u8 = 7,
+    alt_saved_bg: u8 = 0,
+    alt_saved_fg_rgb: ?[3]u8 = null,
+    alt_saved_bg_rgb: ?[3]u8 = null,
+    alt_saved_ul_color_rgb: ?[3]u8 = null,
+    alt_saved_charset: u2 = 0,
+    alt_saved_charsets: [4]CharsetType = .{ .us_ascii, .us_ascii, .us_ascii, .us_ascii },
+
     pub fn init(allocator: Allocator, cols: u32, rows: u32) !Self {
         const total = @as(usize, cols) * @as(usize, rows);
         const cells = try allocator.alloc(Cell, total);

--- a/src/term.zig
+++ b/src/term.zig
@@ -121,7 +121,7 @@ pub const Term = struct {
     current_hyperlink_id: u16 = 0,
 
     // VT response buffer — accumulated responses flushed by event loop via ptyBufferedWrite
-    vt_response_buf: [1024]u8 = undefined,
+    vt_response_buf: [4096]u8 = undefined,
     vt_response_len: u16 = 0,
 
     // OSC 52 clipboard output
@@ -171,6 +171,7 @@ pub const Term = struct {
     title: [256]u8 = undefined,
     title_len: u8 = 0,
     title_changed: bool = false,
+    bell_pending: bool = false,
 
     // Focus event tracking (DECSET ?1004)
     focus_events: bool = false,

--- a/src/term.zig
+++ b/src/term.zig
@@ -170,6 +170,7 @@ pub const Term = struct {
     // Window/icon title (OSC 0/1/2)
     title: [256]u8 = undefined,
     title_len: u8 = 0,
+    title_changed: bool = false,
 
     // Focus event tracking (DECSET ?1004)
     focus_events: bool = false,

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -1734,11 +1734,19 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
             },
             1049 => {
                 if (set) {
+                    // Save cursor, scroll region, wrap state, and SGR drawing state
                     term.saved_cursor_x = term.cursor_x;
                     term.saved_cursor_y = term.cursor_y;
                     term.saved_scroll_top = term.scroll_top;
                     term.saved_scroll_bottom = term.scroll_bottom;
                     term.saved_wrap_next = term.wrap_next;
+                    term.saved_attrs = term.current_attrs;
+                    term.saved_fg = term.current_fg;
+                    term.saved_bg = term.current_bg;
+                    term.saved_fg_rgb = term.current_fg_rgb;
+                    term.saved_bg_rgb = term.current_bg_rgb;
+                    term.saved_ul_color_rgb = term.current_ul_color_rgb;
+                    term.saved_charset = term.charset;
                     term.switchScreen(true) catch |err| {
                         std.log.err("switchScreen failed: {}", .{err});
                     };
@@ -1750,11 +1758,19 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     term.switchScreen(false) catch |err| {
                         std.log.err("switchScreen failed: {}", .{err});
                     };
+                    // Restore cursor, scroll region, wrap state, and SGR drawing state
                     term.cursor_x = @min(term.saved_cursor_x, term.cols -| 1);
                     term.cursor_y = @min(term.saved_cursor_y, term.rows -| 1);
                     term.scroll_top = @min(term.saved_scroll_top, term.rows -| 1);
                     term.scroll_bottom = @min(term.saved_scroll_bottom, term.rows -| 1);
                     term.wrap_next = term.saved_wrap_next;
+                    term.current_attrs = term.saved_attrs;
+                    term.current_fg = term.saved_fg;
+                    term.current_bg = term.saved_bg;
+                    term.current_fg_rgb = term.saved_fg_rgb;
+                    term.current_bg_rgb = term.saved_bg_rgb;
+                    term.current_ul_color_rgb = term.saved_ul_color_rgb;
+                    term.charset = term.saved_charset;
                 }
             },
             2004 => term.bracketed_paste = set,

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -1211,7 +1211,7 @@ fn handleControl(c: u8, term: *Term) void {
             if (term.cursor_x > 0) term.cursor_x -= 1;
         },
         0x09 => term.tputtab(1), // HT — advance to next tab stop
-        0x07 => {}, // BEL — ignore
+        0x07 => term.bell_pending = true, // BEL
         0x0E => term.charset = 1, // SO (LS1 — Locking shift 1, activate G1)
         0x0F => term.charset = 0, // SI (LS0 — Locking shift 0, activate G0)
         else => {},

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -10,7 +10,8 @@ const testing = std.testing;
 
 pub const CsiAction = struct {
     params: [16]u16 = [_]u16{0} ** 16,
-    sub_params: [16]u16 = [_]u16{0} ** 16,
+    sub_params: [16][5]u16 = [_][5]u16{[_]u16{0} ** 5} ** 16,
+    sub_param_counts: [16]u3 = [_]u3{0} ** 16,
     has_sub: u16 = 0, // bitmask: bit i set = params[i] has a sub-param
     param_count: u8 = 0,
     intermediates: [2]u8 = [_]u8{0} ** 2,
@@ -62,7 +63,8 @@ pub const Parser = struct {
     intermediate_count: u8 = 0,
     private_marker: u8 = 0,
     in_subparam: bool = false,
-    sub_params: [16]u16 = [_]u16{0} ** 16,
+    sub_params: [16][5]u16 = [_][5]u16{[_]u16{0} ** 5} ** 16,
+    sub_param_counts: [16]u3 = [_]u3{0} ** 16,
     has_sub: u16 = 0, // bitmask: bit i set = params[i] has a sub-param
     // UTF-8 accumulator
     utf8_buf: [4]u8 = undefined,
@@ -269,10 +271,13 @@ pub const Parser = struct {
     fn handleCsiParam(self: *Parser, byte: u8) Action {
         if (byte >= '0' and byte <= '9') {
             if (self.in_subparam) {
-                // Accumulate first colon sub-parameter digit
+                // Accumulate colon sub-parameter digit
                 const idx = self.param_count;
                 if (idx < 16) {
-                    self.sub_params[idx] = self.sub_params[idx] *| 10 +| (byte - '0');
+                    const si = self.sub_param_counts[idx];
+                    if (si < 5) {
+                        self.sub_params[idx][si] = self.sub_params[idx][si] *| 10 +| (byte - '0');
+                    }
                 }
             } else {
                 const idx = self.param_count;
@@ -282,16 +287,20 @@ pub const Parser = struct {
             }
             return .none;
         } else if (byte == ':') {
-            // Colon sub-parameter separator (e.g., \e[4:3m)
+            // Colon sub-parameter separator (e.g., \e[4:3m, \e[38:2:r:g:bm)
+            const idx = self.param_count;
             if (!self.in_subparam) {
-                // First colon: mark this param as having a sub-param
-                const idx = self.param_count;
+                // First colon: mark this param as having sub-params
                 if (idx < 16) {
                     self.has_sub |= @as(u16, 1) << @intCast(idx);
                 }
                 self.in_subparam = true;
+            } else {
+                // Subsequent colon: advance to next sub-param slot
+                if (idx < 16 and self.sub_param_counts[idx] < 4) {
+                    self.sub_param_counts[idx] += 1;
+                }
             }
-            // Subsequent colons (e.g., 58:2::r:g:b) — ignore for now
             return .none;
         } else if (byte == ';') {
             // Next param — ends any sub-parameter
@@ -416,7 +425,8 @@ pub const Parser = struct {
 
     fn clearCsi(self: *Parser) void {
         self.params = [_]u16{0} ** 16;
-        self.sub_params = [_]u16{0} ** 16;
+        self.sub_params = [_][5]u16{[_]u16{0} ** 5} ** 16;
+        self.sub_param_counts = [_]u3{0} ** 16;
         self.has_sub = 0;
         self.param_count = 0;
         self.intermediates = [_]u8{0} ** 2;
@@ -429,6 +439,7 @@ pub const Parser = struct {
         return CsiAction{
             .params = self.params,
             .sub_params = self.sub_params,
+            .sub_param_counts = self.sub_param_counts,
             .has_sub = self.has_sub,
             .param_count = self.param_count,
             .intermediates = self.intermediates,
@@ -1515,7 +1526,7 @@ fn handleSgr(csi: CsiAction, term: *Term) void {
             4 => {
                 // Check for sub-param (4:N styled underline)
                 if (csi.has_sub & (@as(u16, 1) << @intCast(i)) != 0) {
-                    const style = csi.sub_params[i];
+                    const style = csi.sub_params[i][0];
                     term.current_attrs.underline_style = if (style <= 5) @intCast(style) else 1;
                 } else {
                     term.current_attrs.underline_style = 1; // single
@@ -1538,8 +1549,12 @@ fn handleSgr(csi: CsiAction, term: *Term) void {
             29 => term.current_attrs.strikethrough = false,
             30...37 => term.current_fg = @intCast(param - 30),
             38 => {
-                // Extended foreground
-                i = parseExtendedColor(p, pc, i, term, true);
+                // Extended foreground: colon form (38:2:r:g:b) or semicolon (38;2;r;g;b)
+                if (csi.has_sub & (@as(u16, 1) << @intCast(i)) != 0) {
+                    parseColonColor(csi.sub_params[i][0..], csi.sub_param_counts[i] + 1, term, .fg);
+                } else {
+                    i = parseExtendedColor(p, pc, i, term, true);
+                }
             },
             39 => {
                 term.current_fg = 7;
@@ -1547,16 +1562,24 @@ fn handleSgr(csi: CsiAction, term: *Term) void {
             },
             40...47 => term.current_bg = @intCast(param - 40),
             48 => {
-                // Extended background
-                i = parseExtendedColor(p, pc, i, term, false);
+                // Extended background: colon form (48:2:r:g:b) or semicolon (48;2;r;g;b)
+                if (csi.has_sub & (@as(u16, 1) << @intCast(i)) != 0) {
+                    parseColonColor(csi.sub_params[i][0..], csi.sub_param_counts[i] + 1, term, .bg);
+                } else {
+                    i = parseExtendedColor(p, pc, i, term, false);
+                }
             },
             49 => {
                 term.current_bg = 0;
                 term.current_bg_rgb = null;
             },
             58 => {
-                // Extended underline color (58;2;r;g;b or 58;5;n)
-                i = parseUnderlineColor(p, pc, i, term);
+                // Extended underline color: colon form (58:2:r:g:b) or semicolon (58;2;r;g;b)
+                if (csi.has_sub & (@as(u16, 1) << @intCast(i)) != 0) {
+                    parseColonColor(csi.sub_params[i][0..], csi.sub_param_counts[i] + 1, term, .ul);
+                } else {
+                    i = parseUnderlineColor(p, pc, i, term);
+                }
             },
             59 => term.current_ul_color_rgb = null,
             90...97 => term.current_fg = @intCast(param - 90 + 8),
@@ -1597,6 +1620,46 @@ fn parseExtendedColor(p: [16]u16, pc: u8, start: u8, term: *Term, is_fg: bool) u
         }
     }
     return i;
+}
+
+const ColorTarget = enum { fg, bg, ul };
+
+/// Parse colon-form extended color: sub-params are [type, ...values]
+/// Handles 2:r:g:b, 2::r:g:b (with empty colorspace), and 5:n
+fn parseColonColor(subs: []const u16, count: u3, term: *Term, target: ColorTarget) void {
+    if (count < 1) return;
+    const color_type = subs[0];
+    if (color_type == 5 and count >= 2) {
+        // 256-color: 38:5:n
+        if (subs[1] > 255) return;
+        const color: u8 = @intCast(subs[1]);
+        switch (target) {
+            .fg => {
+                term.current_fg = color;
+                term.current_fg_rgb = null;
+            },
+            .bg => {
+                term.current_bg = color;
+                term.current_bg_rgb = null;
+            },
+            .ul => {},
+        }
+    } else if (color_type == 2) {
+        // TrueColor: 38:2:r:g:b or 38:2::r:g:b (empty colorspace id)
+        // Find r,g,b — skip optional colorspace param
+        var ri: u3 = 1;
+        if (count >= 5 and subs[1] == 0) ri = 2; // 38:2::r:g:b (empty colorspace)
+        if (ri + 2 >= count) return;
+        if (subs[ri] > 255 or subs[ri + 1] > 255 or subs[ri + 2] > 255) return;
+        const r: u8 = @intCast(subs[ri]);
+        const g: u8 = @intCast(subs[ri + 1]);
+        const b: u8 = @intCast(subs[ri + 2]);
+        switch (target) {
+            .fg => term.current_fg_rgb = .{ r, g, b },
+            .bg => term.current_bg_rgb = .{ r, g, b },
+            .ul => term.current_ul_color_rgb = .{ r, g, b },
+        }
+    }
 }
 
 fn resetSgr(term: *Term) void {

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -757,6 +757,7 @@ fn handleOsc(payload: []const u8, term: *Term) void {
             const len = @min(param.len, 255);
             @memcpy(term.title[0..len], param[0..len]);
             term.title_len = @intCast(len);
+            term.title_changed = true;
         },
         1 => {}, // Set icon name only — silently accept
         4 => {}, // Set color palette — silently accept

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -1738,20 +1738,20 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
             },
             1049 => {
                 if (set) {
-                    // Save cursor, scroll region, wrap state, and SGR drawing state
-                    term.saved_cursor_x = term.cursor_x;
-                    term.saved_cursor_y = term.cursor_y;
-                    term.saved_scroll_top = term.scroll_top;
-                    term.saved_scroll_bottom = term.scroll_bottom;
-                    term.saved_wrap_next = term.wrap_next;
-                    term.saved_attrs = term.current_attrs;
-                    term.saved_fg = term.current_fg;
-                    term.saved_bg = term.current_bg;
-                    term.saved_fg_rgb = term.current_fg_rgb;
-                    term.saved_bg_rgb = term.current_bg_rgb;
-                    term.saved_ul_color_rgb = term.current_ul_color_rgb;
-                    term.saved_charset = term.charset;
-                    term.saved_charsets = term.charsets;
+                    // Save to alt_saved_* (separate from DECSC/DECRC saved_*)
+                    term.alt_saved_cursor_x = term.cursor_x;
+                    term.alt_saved_cursor_y = term.cursor_y;
+                    term.alt_saved_scroll_top = term.scroll_top;
+                    term.alt_saved_scroll_bottom = term.scroll_bottom;
+                    term.alt_saved_wrap_next = term.wrap_next;
+                    term.alt_saved_attrs = term.current_attrs;
+                    term.alt_saved_fg = term.current_fg;
+                    term.alt_saved_bg = term.current_bg;
+                    term.alt_saved_fg_rgb = term.current_fg_rgb;
+                    term.alt_saved_bg_rgb = term.current_bg_rgb;
+                    term.alt_saved_ul_color_rgb = term.current_ul_color_rgb;
+                    term.alt_saved_charset = term.charset;
+                    term.alt_saved_charsets = term.charsets;
                     term.switchScreen(true) catch |err| {
                         std.log.err("switchScreen failed: {}", .{err});
                     };
@@ -1763,20 +1763,20 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     term.switchScreen(false) catch |err| {
                         std.log.err("switchScreen failed: {}", .{err});
                     };
-                    // Restore cursor, scroll region, wrap state, and SGR drawing state
-                    term.cursor_x = @min(term.saved_cursor_x, term.cols -| 1);
-                    term.cursor_y = @min(term.saved_cursor_y, term.rows -| 1);
-                    term.scroll_top = @min(term.saved_scroll_top, term.rows -| 1);
-                    term.scroll_bottom = @min(term.saved_scroll_bottom, term.rows -| 1);
-                    term.wrap_next = term.saved_wrap_next;
-                    term.current_attrs = term.saved_attrs;
-                    term.current_fg = term.saved_fg;
-                    term.current_bg = term.saved_bg;
-                    term.current_fg_rgb = term.saved_fg_rgb;
-                    term.current_bg_rgb = term.saved_bg_rgb;
-                    term.current_ul_color_rgb = term.saved_ul_color_rgb;
-                    term.charset = term.saved_charset;
-                    term.charsets = term.saved_charsets;
+                    // Restore from alt_saved_* (separate from DECSC/DECRC saved_*)
+                    term.cursor_x = @min(term.alt_saved_cursor_x, term.cols -| 1);
+                    term.cursor_y = @min(term.alt_saved_cursor_y, term.rows -| 1);
+                    term.scroll_top = @min(term.alt_saved_scroll_top, term.rows -| 1);
+                    term.scroll_bottom = @min(term.alt_saved_scroll_bottom, term.rows -| 1);
+                    term.wrap_next = term.alt_saved_wrap_next;
+                    term.current_attrs = term.alt_saved_attrs;
+                    term.current_fg = term.alt_saved_fg;
+                    term.current_bg = term.alt_saved_bg;
+                    term.current_fg_rgb = term.alt_saved_fg_rgb;
+                    term.current_bg_rgb = term.alt_saved_bg_rgb;
+                    term.current_ul_color_rgb = term.alt_saved_ul_color_rgb;
+                    term.charset = term.alt_saved_charset;
+                    term.charsets = term.alt_saved_charsets;
                 }
             },
             2004 => term.bracketed_paste = set,

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -1642,7 +1642,11 @@ fn parseColonColor(subs: []const u16, count: u3, term: *Term, target: ColorTarge
                 term.current_bg = color;
                 term.current_bg_rgb = null;
             },
-            .ul => {},
+            .ul => {
+                const render = @import("render.zig");
+                const pal = render.palette[color];
+                term.current_ul_color_rgb = .{ pal.r, pal.g, pal.b };
+            },
         }
     } else if (color_type == 2) {
         // TrueColor: 38:2:r:g:b or 38:2::r:g:b (empty colorspace id)
@@ -1747,6 +1751,7 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     term.saved_bg_rgb = term.current_bg_rgb;
                     term.saved_ul_color_rgb = term.current_ul_color_rgb;
                     term.saved_charset = term.charset;
+                    term.saved_charsets = term.charsets;
                     term.switchScreen(true) catch |err| {
                         std.log.err("switchScreen failed: {}", .{err});
                     };
@@ -1771,6 +1776,7 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     term.current_bg_rgb = term.saved_bg_rgb;
                     term.current_ul_color_rgb = term.saved_ul_color_rgb;
                     term.charset = term.saved_charset;
+                    term.charsets = term.saved_charsets;
                 }
             },
             2004 => term.bracketed_paste = set,


### PR DESCRIPTION
## **User description**
## Summary
- **OSC window title propagation** — `term.title` from OSC 0/2 now pushed to X11 (`WM_NAME`) and Wayland (`xdg_toplevel.set_title`) after each render
- **Paste buffer 4KB→64KB** — PasteEvent and clipboard buffers increased across all backends (X11, Wayland, macOS) to stop silently truncating large pastes
- **Colon-form TrueColor** — `38:2:r:g:b` / `48:2:r:g:b` / `58:2:r:g:b` now parsed correctly (sub_params expanded to [16][5]u16)
- **Alt screen SGR save/restore** — DECSET `?1049` now saves and restores full drawing state (attrs, colors, charset), preventing SGR leaks after vim/tmux exit
- **X11 KEY_RELEASE XKB update** — modifier state now synced on key release; release events no longer returned as useless backend events (saves one epoll wakeup per keystroke)
- **VT response buffer 1KB→4KB** — prevents silent DA1/DECRQM drops during tmux/neovim startup query bursts
- **BEL handling** — 0x07 now triggers `xcb_bell()` on X11 instead of being silently ignored

## Test plan
- [ ] `printf '\033]0;hello\007'` → window title changes to "hello"
- [ ] Paste >4KB text → no truncation
- [ ] `printf '\033[38:2:255:0:0mRED\033[0m'` → red text
- [ ] vim → `:q` → no lingering bold/color on the shell
- [ ] CapsLock + type → correct case
- [ ] `printf '\a'` → audible bell

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Propagate titles, larger pastes, and full text styling across terminal sessions**

### What Changed
- Window titles set by apps now appear in the window manager title on both X11 and Wayland.
- Pasting large text no longer cuts off at 4 KB; paste handling now accepts much larger clipboard content across supported backends.
- Colon-form color sequences now render correctly, including full TrueColor and underline color values.
- Switching to and from the alternate screen now restores the full text style state, so colors and formatting do not leak back into the shell.
- BEL now triggers the terminal bell instead of being ignored, and X11 key releases now keep modifier state in sync while avoiding extra release events.

### Impact
`✅ Accurate window titles in terminal apps`
`✅ Fewer truncated large pastes`
`✅ Correct colors after exiting vim or tmux`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ターミナルエスケープ経由でウィンドウタイトルを更新可能に（描画後に適用）
  * ベル（ビープ）発生機能を追加（描画後に発火）
  * アンダーラインスタイルとコロン形式の拡張色をサポート
  * 代替画面モード（DECSET 1049）での描画状態・文字セットの保存・復元を強化

* **改善**
  * クリップボード受信バッファを4KBから16KBに拡大
  * VT応答キュー用バッファを1KBから4KBに拡大
<!-- end of auto-generated comment: release notes by coderabbit.ai -->