### PR TITLE
Fix 23 bugs: VT compliance, PTY safety, input mapping, Wayland key repeat

### DIFF
--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -671,7 +671,7 @@ pub const WaylandBackend = struct {
     // ========================================================================
 
     pub fn getFd(self: *Self) ?posix.fd_t {
-        return self.conn.fd;
+        return self.internal_epoll_fd;
     }
 
     // ========================================================================

--- a/src/font.zig
+++ b/src/font.zig
@@ -80,6 +80,7 @@ pub fn FontBlob(comptime blob: []const u8) type {
             if (codepoint < 128) return ascii_cache[codepoint];
 
             // Runtime cache for non-ASCII (function-local static via struct pattern)
+            // SAFETY: only called from single-threaded render path
             const S = struct {
                 const CACHE_SIZE: usize = 256;
                 // valid=false means empty slot (avoids confusion with codepoint 0)

--- a/src/input.zig
+++ b/src/input.zig
@@ -465,6 +465,18 @@ pub fn translateKey(keycode: u16, mods: Modifiers, decckm: bool, decbkm: bool) [
                 return S.buf[0..1];
             }
 
+            // Ctrl+symbol → C0 control characters (Ctrl+[ = ESC, Ctrl+\ = FS, Ctrl+] = GS, etc.)
+            if (mods.ctrl and entry.normal >= '@' and entry.normal <= '_') {
+                const ctrl_char: u8 = entry.normal - '@';
+                if (mods.alt) {
+                    S.buf[0] = 0x1b;
+                    S.buf[1] = ctrl_char;
+                    return S.buf[0..2];
+                }
+                S.buf[0] = ctrl_char;
+                return S.buf[0..1];
+            }
+
             const ch: u8 = if (mods.shift) entry.shifted else entry.normal;
             if (mods.alt) {
                 S.buf[0] = 0x1b;

--- a/src/input.zig
+++ b/src/input.zig
@@ -466,8 +466,10 @@ pub fn translateKey(keycode: u16, mods: Modifiers, decckm: bool, decbkm: bool) [
             }
 
             // Ctrl+symbol → C0 control characters (Ctrl+[ = ESC, Ctrl+\ = FS, Ctrl+] = GS, etc.)
-            if (mods.ctrl and entry.normal >= '@' and entry.normal <= '_') {
-                const ctrl_char: u8 = entry.normal - '@';
+            // Use shifted value when Shift is held (e.g., Ctrl+Shift+2 → '@' → NUL)
+            const ctrl_source: u8 = if (mods.shift) entry.shifted else entry.normal;
+            if (mods.ctrl and ctrl_source >= '@' and ctrl_source <= '_') {
+                const ctrl_char: u8 = ctrl_source - '@';
                 if (mods.alt) {
                     S.buf[0] = 0x1b;
                     S.buf[1] = ctrl_char;

--- a/src/main.zig
+++ b/src/main.zig
@@ -263,6 +263,8 @@ fn ptyBufferedWrite(
         error.WouldBlock => {
             // Buffer everything — chunk if data exceeds buffer capacity
             const to_buf = @min(data.len, write_buf.len);
+            if (data.len > write_buf.len)
+                std.log.warn("PTY write truncated: {d} bytes dropped", .{data.len - write_buf.len});
             @memcpy(write_buf[0..to_buf], data[0..to_buf]);
             write_pending.* = to_buf;
             if (is_linux) {
@@ -279,6 +281,8 @@ fn ptyBufferedWrite(
     if (written < data.len) {
         const remaining = data.len - written;
         const to_buf = @min(remaining, write_buf.len);
+        if (remaining > write_buf.len)
+            std.log.warn("PTY write truncated: {d} bytes dropped", .{remaining - write_buf.len});
         @memcpy(write_buf[0..to_buf], data[written .. written + to_buf]);
         write_pending.* = to_buf;
         if (is_linux) {

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -47,7 +47,10 @@ pub const Pty = struct {
             const fd = c.posix_openpt(@as(c_int, 2 | 0x20000));
             if (fd < 0) return error.OpenFailed;
             // Set CLOEXEC to prevent master_fd leaking to child processes
-            _ = c.fcntl(fd, @as(c_int, 2), @as(c_int, 1)); // F_SETFD=2, FD_CLOEXEC=1
+            if (c.fcntl(fd, @as(c_int, 2), @as(c_int, 1)) < 0) { // F_SETFD=2, FD_CLOEXEC=1
+                _ = c.close(fd);
+                return error.OpenFailed;
+            }
             break :blk @intCast(fd);
         } else try posix.open(
             "/dev/ptmx",

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -46,10 +46,12 @@ pub const Pty = struct {
             // O_RDWR=2, O_NOCTTY=0x20000 on macOS
             const fd = c.posix_openpt(@as(c_int, 2 | 0x20000));
             if (fd < 0) return error.OpenFailed;
+            // Set CLOEXEC to prevent master_fd leaking to child processes
+            _ = c.fcntl(fd, @as(c_int, 2), @as(c_int, 1)); // F_SETFD=2, FD_CLOEXEC=1
             break :blk @intCast(fd);
         } else try posix.open(
             "/dev/ptmx",
-            .{ .ACCMODE = .RDWR, .NOCTTY = true },
+            .{ .ACCMODE = .RDWR, .NOCTTY = true, .CLOEXEC = true },
             0,
         );
         errdefer posix.close(master_fd);
@@ -106,6 +108,12 @@ pub const Pty = struct {
                 _ = std.c.setsid();
             } else {
                 _ = linux.syscall0(.setsid);
+            }
+
+            // Reset signal mask — parent may have blocked signals for signalfd
+            if (is_linux) {
+                var empty_set = linux.sigemptyset();
+                _ = linux.sigprocmask(linux.SIG.SETMASK, &empty_set, null);
             }
 
             // b. Open slave fd
@@ -263,9 +271,9 @@ pub const Pty = struct {
     }
 
     pub fn deinit(self: *Pty) void {
-        posix.close(self.master_fd);
-        // Kill child if still running
+        // Kill child first, then close — avoids SIGHUP+SIGTERM race
         posix.kill(self.child_pid, posix.SIG.TERM) catch {};
+        posix.close(self.master_fd);
         // Use WNOHANG: child may already be reaped by SIGCHLD handler
         const WNOHANG: u32 = if (@import("builtin").os.tag == .linux) std.os.linux.W.NOHANG else 1;
         _ = posix.waitpid(self.child_pid, WNOHANG);

--- a/src/term.zig
+++ b/src/term.zig
@@ -200,6 +200,7 @@ pub const Term = struct {
     alt_saved_cursor_y: u32 = 0,
     alt_saved_scroll_top: u32 = 0,
     alt_saved_scroll_bottom: u32 = 0,
+    alt_has_truecolor_cells: bool = false,
     alt_saved_wrap_next: bool = false,
     alt_saved_attrs: Cell.Attrs = .{},
     alt_saved_fg: u8 = 7,
@@ -553,6 +554,10 @@ pub const Term = struct {
         self.cursor_x = @min(self.cursor_x, new_cols -| 1);
         self.cursor_y = @min(self.cursor_y, new_rows -| 1);
 
+        // Clamp alt-screen saved scroll region to new dimensions
+        self.alt_saved_scroll_top = @min(self.alt_saved_scroll_top, new_rows -| 1);
+        self.alt_saved_scroll_bottom = @min(self.alt_saved_scroll_bottom, new_rows -| 1);
+
         // Resize alt buffer if allocated — allocate all new buffers first,
         // then free old ones, so OOM leaves the old buffers intact (no UAF).
         if (self.alt_cells != null or self.alt_row_map != null or self.alt_dirty != null or self.alt_fg_rgb != null or self.alt_bg_rgb != null) {
@@ -692,6 +697,11 @@ pub const Term = struct {
         const tmp_hl = self.hyperlink_ids;
         self.hyperlink_ids = self.alt_hyperlink_ids.?;
         self.alt_hyperlink_ids = tmp_hl;
+
+        // Swap truecolor tracking flag between screens
+        const tmp_tc = self.has_truecolor_cells;
+        self.has_truecolor_cells = self.alt_has_truecolor_cells;
+        self.alt_has_truecolor_cells = tmp_tc;
 
         self.is_alt_screen = alt;
         self.markDirtyRange(.{ .start = 0, .end = total });

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -126,8 +126,11 @@ pub const Parser = struct {
             self.utf8_expected = 4;
             self.state = .utf8;
             return .none;
+        } else if (byte >= 0x80 and byte <= 0xBF) {
+            // Unexpected continuation byte — emit replacement character
+            return Action{ .print = 0xFFFD };
         } else {
-            // 0x7F (DEL) or invalid lead bytes — ignore
+            // 0x7F (DEL) or invalid lead bytes (0xF8-0xFF) — ignore
             return .none;
         }
     }
@@ -263,6 +266,10 @@ pub const Parser = struct {
             self.intermediate_count = 1;
             self.state = .csi_intermediate;
             return .none;
+        } else if (byte == 0x1B) {
+            // ESC aborts current CSI and transitions to escape state
+            self.state = .escape;
+            return .none;
         } else {
             return .none;
         }
@@ -324,6 +331,9 @@ pub const Parser = struct {
             // Malformed (but NOT 0x3A which is ':')
             self.state = .csi_ignore;
             return .none;
+        } else if (byte == 0x1B) {
+            self.state = .escape;
+            return .none;
         } else {
             return .none;
         }
@@ -339,6 +349,9 @@ pub const Parser = struct {
         } else if (byte >= 0x40 and byte <= 0x7E) {
             self.state = .ground;
             return Action{ .csi_dispatch = self.buildCsiAction(byte) };
+        } else if (byte == 0x1B) {
+            self.state = .escape;
+            return .none;
         } else {
             self.state = .csi_ignore;
             return .none;
@@ -348,6 +361,8 @@ pub const Parser = struct {
     fn handleCsiIgnore(self: *Parser, byte: u8) Action {
         if (byte >= 0x40 and byte <= 0x7E) {
             self.state = .ground;
+        } else if (byte == 0x1B) {
+            self.state = .escape;
         }
         return .none;
     }
@@ -617,7 +632,7 @@ pub fn feedBulk(parser: *Parser, data: []const u8, term: *Term, writer_fd: ?std.
         // Decode directly, bypassing per-byte parser state machine overhead.
         // Non-wide chars written directly to cells[] with batch dirty marking.
         if (parser.state == .ground and data[i] >= 0xC0 and data[i] < 0xFE and
-            !term.insert_mode)
+            !term.insert_mode and term.charsets[term.charset] == .us_ascii)
         {
             const start_i = i;
             var dirty_run_start: usize = @as(usize, term.cursor_y) * @as(usize, term.cols) + term.cursor_x;
@@ -1259,14 +1274,24 @@ fn handleCsi(csi: CsiAction, term: *Term) void {
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
             term.moveCursorRel(-@as(i32, @intCast(n)), 0);
         },
-        'E' => { // CNL — cursor next line
+        'E' => { // CNL — cursor next line (respects scroll region)
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
-            term.moveCursorRel(0, @as(i32, @intCast(n)));
+            term.wrap_next = false;
+            const max_y: u32 = if (term.cursor_y >= term.scroll_top and term.cursor_y <= term.scroll_bottom)
+                term.scroll_bottom
+            else
+                term.rows -| 1;
+            term.cursor_y = @min(term.cursor_y + n, max_y);
             term.cursor_x = 0;
         },
-        'F' => { // CPL — cursor preceding line
+        'F' => { // CPL — cursor preceding line (respects scroll region)
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
-            term.moveCursorRel(0, -@as(i32, @intCast(n)));
+            term.wrap_next = false;
+            const min_y: u32 = if (term.cursor_y >= term.scroll_top and term.cursor_y <= term.scroll_bottom)
+                term.scroll_top
+            else
+                0;
+            term.cursor_y = if (term.cursor_y >= n) @max(term.cursor_y - n, min_y) else min_y;
             term.cursor_x = 0;
         },
         'G', '`' => { // CHA/HPA — cursor horizontal absolute (1-indexed)
@@ -1350,7 +1375,8 @@ fn handleCsi(csi: CsiAction, term: *Term) void {
                     term.queueResponse("\x1b[0n");
                 } else if (p[0] == 6) {
                     var buf: [32]u8 = undefined;
-                    const response = std.fmt.bufPrint(&buf, "\x1b[{d};{d}R", .{ term.cursor_y + 1, term.cursor_x + 1 }) catch return;
+                    const report_row = if (term.origin_mode) term.cursor_y -| term.scroll_top + 1 else term.cursor_y + 1;
+                    const response = std.fmt.bufPrint(&buf, "\x1b[{d};{d}R", .{ report_row, term.cursor_x + 1 }) catch return;
                     term.queueResponse(response);
                 }
             }
@@ -1367,8 +1393,8 @@ fn handleCsi(csi: CsiAction, term: *Term) void {
             const n = if (pc > 0 and p[0] > 0) p[0] else 1;
             const ch = term.last_printed_char;
             if (ch > 0) {
-                const count = @min(n, @as(u16, @intCast(term.cols)) *| @as(u16, @intCast(term.rows)));
-                var rep: u16 = 0;
+                const count = @min(@as(u32, n), @as(u32, term.cols) *| @as(u32, term.rows));
+                var rep: u32 = 0;
                 while (rep < count) : (rep += 1) {
                     handlePrint(ch, term);
                 }
@@ -1384,7 +1410,7 @@ fn handleCsi(csi: CsiAction, term: *Term) void {
                 const bot = if (pc > 1 and p[1] > 0) p[1] - 1 else @as(u16, @intCast(term.rows -| 1));
                 term.setScrollRegion(@intCast(top), @intCast(bot));
                 term.cursor_x = 0;
-                term.cursor_y = 0;
+                term.cursor_y = if (term.origin_mode) term.scroll_top else 0;
                 term.wrap_next = false;
             }
         },
@@ -1787,6 +1813,11 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
                     term.cursor_y = @min(term.alt_saved_cursor_y, term.rows -| 1);
                     term.scroll_top = @min(term.alt_saved_scroll_top, term.rows -| 1);
                     term.scroll_bottom = @min(term.alt_saved_scroll_bottom, term.rows -| 1);
+                    // Validate scroll region invariant after potential resize
+                    if (term.scroll_top >= term.scroll_bottom) {
+                        term.scroll_top = 0;
+                        term.scroll_bottom = term.rows -| 1;
+                    }
                     term.wrap_next = term.alt_saved_wrap_next;
                     term.current_attrs = term.alt_saved_attrs;
                     term.current_fg = term.alt_saved_fg;


### PR DESCRIPTION
## **User description**
## Summary

- **1 High**: PTY master_fd CLOEXEC preventing fd leak to child processes
- **12 Medium**: VT parser ESC handling, DECOM compliance, scroll region fixes, PTY lifecycle, Wayland key repeat, Ctrl+symbol input mappings
- **10 Low**: UTF-8 replacement chars, REP overflow safety, truecolor flag isolation, resize clamping, truncation logging, thread safety docs

## Changes by file

| File | Fixes | Description |
|------|-------|-------------|
| `pty.zig` | H1, M8, M9 | CLOEXEC, deinit kill→close order, child signal mask reset |
| `vt.zig` | M1-M6, L1-L3 | ESC in CSI states, CNL/CPL scroll region, DSR/DECSTBM DECOM, alt screen scroll validation, U+FFFD, REP u32, feedBulk charset |
| `term.zig` | M7, L4 | per-screen truecolor flag, resize clamp alt_saved_scroll |
| `wayland.zig` | M10 | getFd() returns internal_epoll_fd (fixes key repeat stutter) |
| `input.zig` | M12 | Ctrl+[@\]^_ → C0 control characters |
| `main.zig` | M11 | Log warning on PTY write truncation |
| `font.zig` | L5 | Thread safety comment on glyph cache |

## Test plan

- [x] `zig build test` — all 110+ tests pass
- [x] `zig build` (fbdev) — clean
- [x] `zig build -Dbackend=x11` — clean
- [x] `zig build -Dbackend=wayland` — clean
- [ ] Manual: verify Ctrl+[ sends ESC in shell
- [ ] Manual: verify key repeat is smooth on Wayland
- [ ] Manual: verify vim with scroll regions works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix terminal input, scrolling, and PTY behavior in edge cases**

### What Changed
- Ctrl+symbol shortcuts now send the expected control characters, including Ctrl+[ as Escape
- Cursor movement and position reports now follow the active scroll region and origin mode more closely
- Switching to and from the alternate screen now keeps scroll limits and color state from bleeding across screens, even after resize
- Invalid UTF-8 continuation bytes now show a replacement character instead of being dropped, and CSI parsing no longer gets stuck on Escape
- Wayland key repeat uses the correct event source, reducing repeat stutter
- PTY writes now warn when data is cut off, and child processes no longer inherit the master PTY handle

### Impact
`✅ Ctrl+[ and related shortcuts work in more shells and tools`
`✅ Fewer scrolling mistakes in editors and pagers`
`✅ Smoother key repeat on Wayland`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * UTF-8の不正続きバイトを正しく置換（U+FFFD）するよう改善
  * ウィンドウリサイズ時のスクロール領域境界を修正
  * 代替スクリーンのTrueColor状態管理を改善
  * Ctrl/Alt+Ctrlで記号から制御文字を生成する挙動を拡張
  * パーサーのESC処理と状態遷移を強化、CSI関連（CNL/CPL、DSR、DECSTBM、REP、1049復元）を修正

* **改善**
  * 入力書き込みが切り捨てられる際に警告ログを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->