### PR TITLE
[codex] Harden event and paste handling

### DIFF
--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -116,8 +116,7 @@ pub const WaylandBackend = struct {
     internal_epoll_fd: posix.fd_t = -1,
 
     // Event queue (pollEvents returns one event at a time)
-    pending_events: [32]Event = undefined,
-    pending_count: usize = 0,
+    pending_events: std.ArrayListUnmanaged(Event) = .{},
     pending_read: usize = 0,
 
     // Focus state
@@ -412,6 +411,7 @@ pub const WaylandBackend = struct {
 
     pub fn deinit(self: *Self) void {
         self.keyboard.deinit();
+        self.pending_events.deinit(std.heap.c_allocator);
         if (self.shm_buffers) |*bufs| {
             bufs.deinit();
         }
@@ -420,6 +420,9 @@ pub const WaylandBackend = struct {
         }
         if (self.clipboard.paste_pipe_fd >= 0) {
             posix.close(self.clipboard.paste_pipe_fd);
+        }
+        if (self.clipboard.paste_buf.len > 0) {
+            std.heap.c_allocator.free(self.clipboard.paste_buf);
         }
         self.conn.deinit();
     }
@@ -701,20 +704,19 @@ pub const WaylandBackend = struct {
     // ========================================================================
 
     fn queueEvent(self: *Self, event: Event) void {
-        if (self.pending_count < self.pending_events.len) {
-            self.pending_events[self.pending_count] = event;
-            self.pending_count += 1;
-        }
+        self.pending_events.append(std.heap.c_allocator, event) catch {
+            std.log.warn("dropping Wayland event due to OOM", .{});
+        };
     }
 
     fn dequeueEvent(self: *Self) ?Event {
-        if (self.pending_read < self.pending_count) {
-            const event = self.pending_events[self.pending_read];
+        if (self.pending_read < self.pending_events.items.len) {
+            const event = self.pending_events.items[self.pending_read];
             self.pending_read += 1;
             // Reset when fully consumed
-            if (self.pending_read >= self.pending_count) {
+            if (self.pending_read >= self.pending_events.items.len) {
                 self.pending_read = 0;
-                self.pending_count = 0;
+                self.pending_events.clearRetainingCapacity();
             }
             return event;
         }
@@ -795,10 +797,10 @@ pub const WaylandBackend = struct {
                     if (new_w != self.width or new_h != self.height) {
                         var replaced = false;
                         var i: usize = self.pending_read;
-                        while (i < self.pending_count) : (i += 1) {
-                            switch (self.pending_events[i]) {
+                        while (i < self.pending_events.items.len) : (i += 1) {
+                            switch (self.pending_events.items[i]) {
                                 .resize => {
-                                    self.pending_events[i] = .{ .resize = .{ .width = new_w, .height = new_h } };
+                                    self.pending_events.items[i] = .{ .resize = .{ .width = new_w, .height = new_h } };
                                     replaced = true;
                                     break;
                                 },

--- a/src/backend/wayland/clipboard.zig
+++ b/src/backend/wayland/clipboard.zig
@@ -59,6 +59,8 @@ pub const ZWP_PRIMARY_SELECTION_OFFER_EVENT_OFFER: u16 = 0;
 // ============================================================================
 
 pub const ClipboardState = struct {
+    const max_paste_bytes = 1024 * 1024;
+
     // wl_data_device
     data_device_id: u32 = 0,
     current_offer_id: u32 = 0,
@@ -71,7 +73,7 @@ pub const ClipboardState = struct {
 
     // Paste pipe (async read)
     paste_pipe_fd: posix.fd_t = -1,
-    paste_buf: [16384]u8 = undefined,
+    paste_buf: []u8 = &.{},
     paste_len: usize = 0,
 };
 
@@ -138,6 +140,24 @@ pub fn closePastePipe(state: *ClipboardState, epoll_fd: posix.fd_t) void {
     }
 }
 
+fn ensurePasteCapacity(state: *ClipboardState, needed: usize) !void {
+    if (needed <= state.paste_buf.len) return;
+    if (needed > ClipboardState.max_paste_bytes) return error.PasteTooLarge;
+
+    var new_cap: usize = if (state.paste_buf.len == 0) 4096 else state.paste_buf.len;
+    while (new_cap < needed) {
+        new_cap = @min(new_cap * 2, ClipboardState.max_paste_bytes);
+        if (new_cap >= needed) break;
+        if (new_cap == ClipboardState.max_paste_bytes) return error.PasteTooLarge;
+    }
+
+    if (state.paste_buf.len == 0) {
+        state.paste_buf = try std.heap.c_allocator.alloc(u8, new_cap);
+    } else {
+        state.paste_buf = try std.heap.c_allocator.realloc(state.paste_buf, new_cap);
+    }
+}
+
 /// Request paste from the compositor: creates a pipe, sends data_offer.receive
 /// with the write end via SCM_RIGHTS, then stores the read end for async polling.
 ///
@@ -183,7 +203,8 @@ pub fn requestPaste(
 pub fn readPastePipe(state: *ClipboardState) bool {
     if (state.paste_pipe_fd < 0) return false;
 
-    while (state.paste_len < state.paste_buf.len) {
+    while (true) {
+        ensurePasteCapacity(state, state.paste_len + 1) catch return false;
         const remaining = state.paste_buf.len - state.paste_len;
         const n = posix.read(state.paste_pipe_fd, state.paste_buf[state.paste_len..][0..remaining]) catch |err| switch (err) {
             error.WouldBlock => return true, // no more data right now, but pipe still open
@@ -192,8 +213,6 @@ pub fn readPastePipe(state: *ClipboardState) bool {
         if (n == 0) return false; // EOF
         state.paste_len += n;
     }
-    // Buffer full — treat as done (truncate at 4096)
-    return false;
 }
 
 // ============================================================================
@@ -220,6 +239,7 @@ test "ClipboardState default initialization" {
     try std.testing.expect(!state.primary_has_text);
     try std.testing.expectEqual(@as(posix.fd_t, -1), state.paste_pipe_fd);
     try std.testing.expectEqual(@as(usize, 0), state.paste_len);
+    try std.testing.expectEqual(@as(usize, 0), state.paste_buf.len);
 }
 
 test "readPastePipe — EOF on empty pipe" {
@@ -228,6 +248,7 @@ test "readPastePipe — EOF on empty pipe" {
     posix.close(fds[1]); // close write end
 
     var state = ClipboardState{};
+    defer if (state.paste_buf.len > 0) std.heap.c_allocator.free(state.paste_buf);
     state.paste_pipe_fd = fds[0];
     state.paste_len = 0;
 
@@ -244,6 +265,7 @@ test "readPastePipe — reads data then EOF" {
     posix.close(fds[1]);
 
     var state = ClipboardState{};
+    defer if (state.paste_buf.len > 0) std.heap.c_allocator.free(state.paste_buf);
     state.paste_pipe_fd = fds[0];
     state.paste_len = 0;
 

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -102,7 +102,7 @@ pub const X11Backend = struct {
     last_ime_y: i16 = -1,
     pending_event: ?*c.xcb_generic_event_t = null, // event pushed back during coalescing
     keyboard_initialized: bool = false, // XKB + XIM lazy init on first key
-    paste_buf_data: [16384]u8 = undefined,
+    paste_buf_data: []u8 = &.{},
     paste_buf_len: u32 = 0,
     screen_id: c_int = 0,
     // XEmbed state (embedding into another window via -w)
@@ -590,6 +590,9 @@ pub const X11Backend = struct {
         if (self.xkb_state) |s| c.xkb_state_unref(s);
         if (self.xkb_keymap) |km| c.xkb_keymap_unref(km);
         if (self.xkb_ctx) |ctx| c.xkb_context_unref(ctx);
+        if (self.paste_buf_data.len > 0) {
+            std.heap.c_allocator.free(self.paste_buf_data);
+        }
         // Detach SHM from X server
         for (0..2) |i| {
             if (self.buffers[i].len > 0) {
@@ -1095,10 +1098,20 @@ pub const X11Backend = struct {
                     const len: u32 = @intCast(c.xcb_get_property_value_length(reply));
                     if (len > 0) {
                         const data: [*]const u8 = @ptrCast(c.xcb_get_property_value(reply));
-                        const clamped = @min(len, 16384);
-                        @memcpy(self.paste_buf_data[0..clamped], data[0..clamped]);
-                        self.paste_buf_len = clamped;
-                        return .{ .paste = .{ .ptr = &self.paste_buf_data, .len = clamped } };
+                        const needed: usize = len;
+                        if (self.paste_buf_data.len < needed) {
+                            if (self.paste_buf_data.len > 0) {
+                                std.heap.c_allocator.free(self.paste_buf_data);
+                            }
+                            self.paste_buf_data = std.heap.c_allocator.alloc(u8, needed) catch {
+                                self.paste_buf_data = &.{};
+                                self.paste_buf_len = 0;
+                                continue;
+                            };
+                        }
+                        @memcpy(self.paste_buf_data[0..needed], data[0..needed]);
+                        self.paste_buf_len = len;
+                        return .{ .paste = .{ .ptr = self.paste_buf_data.ptr, .len = len } };
                     }
                 }
                 continue; // property data empty — skip

--- a/src/main.zig
+++ b/src/main.zig
@@ -350,8 +350,14 @@ fn handleSignal(sig_fd: std.posix.fd_t, signo_override: ?u32, backend: *Backend)
             // Use raw syscall to handle ECHILD gracefully (std.posix.waitpid panics on it).
             if (is_linux) {
                 while (true) {
-                    // Use raw syscall: waitid(P_ALL=0, 0, NULL, WEXITED|WNOHANG, NULL)
-                    const rc = linux.syscall4(.waitid, 0, 0, 0, linux.W.EXITED | linux.W.NOHANG);
+                    // Use raw syscall: wait4(-1, NULL, WNOHANG, NULL)
+                    const rc = linux.syscall4(
+                        .wait4,
+                        @as(usize, @bitCast(@as(isize, -1))),
+                        0,
+                        linux.W.NOHANG,
+                        0,
+                    );
                     const rc_isize: isize = @bitCast(rc);
                     if (rc_isize <= 0) break; // ECHILD or no more children
                 }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -280,8 +280,8 @@ pub const Pty = struct {
         // Use WNOHANG: child may already be reaped by SIGCHLD handler.
         // Use raw syscall because std.posix.waitpid panics on ECHILD.
         if (is_linux) {
-            // waitid(P_PID=1, pid, NULL, WEXITED|WNOHANG)
-            _ = linux.syscall4(.waitid, 1, @as(usize, @intCast(self.child_pid)), 0, linux.W.EXITED | linux.W.NOHANG);
+            // wait4(pid, NULL, WNOHANG, NULL)
+            _ = linux.syscall4(.wait4, @as(usize, @intCast(self.child_pid)), 0, linux.W.NOHANG, 0);
         } else {
             _ = std.c.waitpid(self.child_pid, null, 1); // WNOHANG=1
         }


### PR DESCRIPTION
## What changed
- replace invalid Linux `waitid` raw-syscall usage with `wait4(..., WNOHANG, ...)` for SIGCHLD handling and PTY teardown
- remove fixed 16 KiB paste truncation in the X11 backend by switching to dynamically sized paste storage
- grow Wayland clipboard paste storage dynamically up to 1 MiB instead of silently truncating
- replace the fixed-size Wayland pending event queue with a dynamic queue to avoid dropping events during bursts

## Why
A code review found three correctness issues:
- child processes could fail to be reaped on Linux, leaving zombies behind
- large clipboard pastes could be silently truncated
- Wayland event bursts could overflow the fixed queue and lose input or resize events

## Impact
- Linux child-process cleanup is now reliable for clipboard helpers and PTY children
- large pastes behave correctly on X11 and Wayland within the configured safety limit
- Wayland input and compositor events are less likely to be lost under load

## Root cause
- `waitid` was called via raw syscall with a null `siginfo_t *`, which is not a valid usage
- clipboard implementations used fixed-size buffers with silent clamping
- the Wayland backend stored pending events in a fixed 32-entry array

## Validation
- `zig build test -Dbackend=x11 --cache-dir /tmp/zt-cache-fix-x11 --global-cache-dir /tmp/zt-global-cache`
- `zig build test -Dbackend=wayland --cache-dir /tmp/zt-cache-fix-wayland --global-cache-dir /tmp/zt-global-cache`
- `zig build test -Dbackend=fbdev --cache-dir /tmp/zt-cache-fix-fbdev --global-cache-dir /tmp/zt-global-cache`
- `zig build -Dbackend=x11 -Doptimize=Debug --cache-dir /tmp/zt-cache-fix-debug2 --global-cache-dir /tmp/zt-global-cache`
- `zig build -Dbackend=x11 -Doptimize=ReleaseFast --cache-dir /tmp/zt-cache-fix-release2 --global-cache-dir /tmp/zt-global-cache`
- `bash ./test-xvfb-local.sh`

## Notes
- macOS runtime validation was not possible in this Linux environment because the required system frameworks are unavailable here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * クリップボード貼り付け機能の容量制限を撤廃。従来の16KBの上限を超える大きなテキストデータの貼り付けが可能になりました。
  * イベント処理とプロセス管理の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->