### PR TITLE
fix: Wayland 入力キュー溢れ + Linux/X11 epoll でのイベント滞留

### DIFF
--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -122,6 +122,7 @@ pub const WaylandBackend = struct {
     pending_events: [256]Event = undefined,
     pending_count: usize = 0,
     pending_read: usize = 0,
+    pending_overflow_warned: bool = false,
 
     // Focus state
     focused: bool = false,
@@ -705,7 +706,10 @@ pub const WaylandBackend = struct {
 
     fn queueEvent(self: *Self, event: Event) void {
         if (self.pending_count >= self.pending_events.len) {
-            std.log.warn("Wayland event queue full; dropping event", .{});
+            if (!self.pending_overflow_warned) {
+                std.log.warn("Wayland event queue full; dropping event", .{});
+                self.pending_overflow_warned = true;
+            }
             return;
         }
         self.pending_events[self.pending_count] = event;
@@ -720,6 +724,7 @@ pub const WaylandBackend = struct {
             if (self.pending_read >= self.pending_count) {
                 self.pending_read = 0;
                 self.pending_count = 0;
+                self.pending_overflow_warned = false;
             }
             return event;
         }

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -115,8 +115,11 @@ pub const WaylandBackend = struct {
     // Internal epoll (wraps wayland socket + key repeat timer + clipboard pipe)
     internal_epoll_fd: posix.fd_t = -1,
 
-    // Event queue (pollEvents returns one event at a time)
-    pending_events: [32]Event = undefined,
+    // Event queue (pollEvents returns one event at a time).
+    // Large enough for IME bursts + fast typing; small queues silently dropped
+    // events and caused lost keys (main ignores key releases, which used to
+    // consume half the slots).
+    pending_events: [256]Event = undefined,
     pending_count: usize = 0,
     pending_read: usize = 0,
 
@@ -701,10 +704,12 @@ pub const WaylandBackend = struct {
     // ========================================================================
 
     fn queueEvent(self: *Self, event: Event) void {
-        if (self.pending_count < self.pending_events.len) {
-            self.pending_events[self.pending_count] = event;
-            self.pending_count += 1;
+        if (self.pending_count >= self.pending_events.len) {
+            std.log.warn("Wayland event queue full; dropping event", .{});
+            return;
         }
+        self.pending_events[self.pending_count] = event;
+        self.pending_count += 1;
     }
 
     fn dequeueEvent(self: *Self) ?Event {
@@ -1065,17 +1070,15 @@ pub const WaylandBackend = struct {
                         .modifiers = mods,
                     } });
                 } else {
-                    // Key released
+                    // Key released — update repeat state only. Do not queue a KeyEvent:
+                    // main.zig only handles pressed==true for PTY output, so releases
+                    // wasted queue slots and could overflow the small pending buffer,
+                    // dropping real keypress/text events.
                     if (self.keyboard.repeat_key) |rk| {
                         if (rk == key) {
                             self.keyboard.stopRepeat();
                         }
                     }
-                    self.queueEvent(.{ .key = .{
-                        .keycode = evdev_keycode,
-                        .pressed = false,
-                        .modifiers = mods,
-                    } });
                 }
             },
             seat_mod.WL_KEYBOARD_EVENT_MODIFIERS => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -790,13 +790,18 @@ pub fn main() !void {
                     },
                     @intFromEnum(EpollTag.backend) => {
                         // Backend events (X11, Wayland or macOS)
-                        // Batch-limited to ensure timer/signal fds are serviced.
-                        // Without this, a flood of X11 events (MotionNotify, XIM
-                        // protocol) can starve the event loop and freeze input/blink.
+                        // Drain pollEvents until the backend queue is empty (same as
+                        // the macOS kqueue path). On Linux+X11, libxcb often reads the
+                        // whole socket into an internal queue; if we stop after a fixed
+                        // number of delivered events while messages remain, the FD is
+                        // no longer readable and epoll will not wake again — input
+                        // appears stuck or very laggy until unrelated X traffic arrives.
+                        // Cap avoids infinite loops if a backend misbehaves; 8k is far
+                        // above normal bursts but still bounded for timer/signal latency.
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
                             var had_input = false;
-                            var batch: u32 = 0;
-                            while (batch < 256) : (batch += 1) {
+                            var drain: u32 = 0;
+                            while (drain < 8192) : (drain += 1) {
                                 const event = backend.pollEvents() orelse break;
                                 if (event == .key or event == .text or event == .paste) had_input = true;
                                 if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
@@ -804,7 +809,6 @@ pub fn main() !void {
                                     break;
                                 }
                             }
-                            // Reset cursor blink on input activity
                             if (had_input) cursor_visible_blink = true;
                         }
                     },


### PR DESCRIPTION
## Wayland（前回コミット）

- キーリリースをメインにキューしていなかったのに近い理由でスロットを浪費していた → リリースはキューしない。
- `pending_events` を 32→256、溢れ時は warn。

## Linux + X11（今回）

**症状の本命になりやすい経路:** Linux の epoll ディスパッチだけ `pollEvents` を **最大 256 回**で打ち切っていた。一方 `xcb_poll_for_event` / libxcb はソケットを先に読み切り、**未処理メッセージをユーザ空間キューに残す**ことがある。この状態では FD は読み可能でなくなり、**epoll が再度起きない** → 残りのキーイベントがソケットに新しいデータが来るまで処理されず、「ラグ」「効かない」に見える。

macOS の kqueue 経路は最初から `pollEvents` を null までドレインしていた。Linux 側を同様にし、異常時用に **8192 回の安全上限**のみ付与。

## 検証

- `zig build test` 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 入力イベントの一時保管容量を拡張し、高速入力やIMEでの応答性を向上しました。
  * バッファ溢れ時の検出と警告ログを追加し、過負荷時の挙動を明確化しました。
  * キーボード処理を見直し、リリース時の不要なイベント登録を抑制して効率化しました。
* **修正**
  * バックエンドのイベント処理を改め、到着イベントを十分に消化するようにしつつ上限を設けて安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->