### PR TITLE
fix: フォーカス復帰時のカーソル点滅と応答性

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -338,14 +338,16 @@ fn refreshCursorBlinkOnUserInput(
 fn applyCursorBlinkTimerTick(
     term: *Term,
     backend_focused: bool,
-    loop_now: i128,
     last_input_ns: i128,
     cursor_blink_active: *bool,
     cursor_visible_blink: *bool,
     idle_timeout_ns: i128,
 ) void {
     if (!backend_focused) return;
-    const idle_ns = loop_now - last_input_ns;
+    // Sample time here, not from the pre-epoll_wait loop timestamp: last_input_ns may be
+    // updated later in the same iteration (focus_in / input), and reusing an older
+    // `loop_now` makes idle_ns negative and misroutes the idle vs blink branches.
+    const idle_ns = std.time.nanoTimestamp() - last_input_ns;
     if (idle_ns > idle_timeout_ns) {
         if (cursor_blink_active.*) {
             cursor_blink_active.* = false;
@@ -847,7 +849,6 @@ pub fn main() !void {
                         applyCursorBlinkTimerTick(
                             &term,
                             backend_focused,
-                            loop_now,
                             last_input_ns,
                             &cursor_blink_active,
                             &cursor_visible_blink,
@@ -974,7 +975,6 @@ pub fn main() !void {
                     applyCursorBlinkTimerTick(
                         &term,
                         backend_focused,
-                        loop_now,
                         last_input_ns,
                         &cursor_blink_active,
                         &cursor_visible_blink,

--- a/src/main.zig
+++ b/src/main.zig
@@ -324,6 +324,41 @@ fn ptyFlushPending(
     return true;
 }
 
+/// Reset cursor blink idle tracking on user input (all backend dispatch paths use handleBackendEvent).
+fn refreshCursorBlinkOnUserInput(
+    cursor_visible_blink: *bool,
+    cursor_blink_active: *bool,
+    last_input_ns: *i128,
+) void {
+    cursor_visible_blink.* = true;
+    cursor_blink_active.* = true;
+    last_input_ns.* = std.time.nanoTimestamp();
+}
+
+fn applyCursorBlinkTimerTick(
+    term: *Term,
+    backend_focused: bool,
+    loop_now: i128,
+    last_input_ns: i128,
+    cursor_blink_active: *bool,
+    cursor_visible_blink: *bool,
+    idle_timeout_ns: i128,
+) void {
+    if (!backend_focused) return;
+    const idle_ns = loop_now - last_input_ns;
+    if (idle_ns > idle_timeout_ns) {
+        if (cursor_blink_active.*) {
+            cursor_blink_active.* = false;
+            cursor_visible_blink.* = true;
+            term.markDirty(term.cursor_x, term.cursor_y);
+        }
+    } else {
+        cursor_blink_active.* = true;
+        cursor_visible_blink.* = !cursor_visible_blink.*;
+        term.markDirty(term.cursor_x, term.cursor_y);
+    }
+}
+
 // =============================================================================
 // Signal handler
 // =============================================================================
@@ -482,6 +517,7 @@ fn handleBackendEvent(
 ) bool {
     switch (event.*) {
         .key => |key_ev| {
+            refreshCursorBlinkOnUserInput(cursor_visible_blink, cursor_blink_active, last_input_ns);
             if (key_ev.pressed) {
                 const bytes = input.translateKey(key_ev.keycode, key_ev.modifiers, term.decckm, term.decbkm);
                 if (bytes.len > 0) {
@@ -492,6 +528,7 @@ fn handleBackendEvent(
             }
         },
         .text => |text_ev| {
+            refreshCursorBlinkOnUserInput(cursor_visible_blink, cursor_blink_active, last_input_ns);
             const text = text_ev.slice();
             if (text.len > 0) {
                 if (!ptyBufferedWrite(pty_ptr, text, write_buf, write_pending, evloop_fd)) {
@@ -500,6 +537,7 @@ fn handleBackendEvent(
             }
         },
         .paste => |paste_ev| {
+            refreshCursorBlinkOnUserInput(cursor_visible_blink, cursor_blink_active, last_input_ns);
             const text = paste_ev.slice();
             if (text.len > 0) {
                 // Wrap paste in bracketed paste sequences if application enabled DECSET 2004
@@ -722,6 +760,7 @@ pub fn main() !void {
     // false while unfocused: skip cursor timer toggles (avoids stale idle blink + extra wakeups)
     var backend_focused = true;
     var last_input_ns: i128 = std.time.nanoTimestamp();
+    const cursor_idle_timeout_ns: i128 = 5 * std.time.ns_per_s;
     var prev_cursor_x: u32 = 0;
     var prev_cursor_y: u32 = 0;
     var write_buf: [65536]u8 = undefined;
@@ -805,25 +844,15 @@ pub fn main() !void {
                         // Read timer to acknowledge
                         var exp: u64 = 0;
                         _ = std.posix.read(timer_fd, std.mem.asBytes(&exp)) catch {};
-                        if (!backend_focused) {
-                            // Unfocused: do not toggle cursor or mark dirty (compositor may throttle us anyway).
-                            continue;
-                        }
-                        // Stop blinking after 5 seconds of no input (like other terminals).
-                        // This avoids continuous rendering during idle, which can trigger
-                        // XCB connection issues and wastes CPU/GPU.
-                        const idle_ns = loop_now - last_input_ns;
-                        if (idle_ns > 5_000_000_000) {
-                            if (cursor_blink_active) {
-                                cursor_blink_active = false;
-                                cursor_visible_blink = true; // show cursor solid
-                                term.markDirty(term.cursor_x, term.cursor_y);
-                            }
-                        } else {
-                            cursor_blink_active = true;
-                            cursor_visible_blink = !cursor_visible_blink;
-                            term.markDirty(term.cursor_x, term.cursor_y);
-                        }
+                        applyCursorBlinkTimerTick(
+                            &term,
+                            backend_focused,
+                            loop_now,
+                            last_input_ns,
+                            &cursor_blink_active,
+                            &cursor_visible_blink,
+                            cursor_idle_timeout_ns,
+                        );
                     },
                     @intFromEnum(EpollTag.backend) => {
                         // Backend events (X11, Wayland or macOS)
@@ -836,20 +865,13 @@ pub fn main() !void {
                         // Cap avoids infinite loops if a backend misbehaves; 8k is far
                         // above normal bursts but still bounded for timer/signal latency.
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
-                            var had_input = false;
                             var drain: u32 = 0;
                             while (drain < 8192) : (drain += 1) {
                                 const event = backend.pollEvents() orelse break;
-                                if (event == .key or event == .text or event == .paste) had_input = true;
                                 if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
                                     running = false;
                                     break;
                                 }
-                            }
-                            if (had_input) {
-                                cursor_visible_blink = true;
-                                cursor_blink_active = true;
-                                last_input_ns = loop_now;
                             }
                         }
                     },
@@ -932,18 +954,11 @@ pub fn main() !void {
                     } else if (kev.udata == @intFromEnum(KqueueTag.backend)) {
                         // Backend events (X11, Wayland or macOS)
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
-                            var had_input = false;
                             while (backend.pollEvents()) |event| {
-                                if (event == .key or event == .text or event == .paste) had_input = true;
                                 if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
                                     running = false;
                                     break;
                                 }
-                            }
-                            if (had_input) {
-                                cursor_visible_blink = true;
-                                cursor_blink_active = true;
-                                last_input_ns = loop_now;
                             }
                         }
                     }
@@ -956,21 +971,15 @@ pub fn main() !void {
                 } else if (kev.filter == std.c.EVFILT.SIGNAL) {
                     running = handleSignal(-1, @intCast(kev.ident), &backend);
                 } else if (kev.filter == std.c.EVFILT.TIMER) {
-                    if (!backend_focused) {
-                        continue;
-                    }
-                    const idle_ns = loop_now - last_input_ns;
-                    if (idle_ns > 5_000_000_000) {
-                        if (cursor_blink_active) {
-                            cursor_blink_active = false;
-                            cursor_visible_blink = true;
-                            term.markDirty(term.cursor_x, term.cursor_y);
-                        }
-                    } else {
-                        cursor_blink_active = true;
-                        cursor_visible_blink = !cursor_visible_blink;
-                        term.markDirty(term.cursor_x, term.cursor_y);
-                    }
+                    applyCursorBlinkTimerTick(
+                        &term,
+                        backend_focused,
+                        loop_now,
+                        last_input_ns,
+                        &cursor_blink_active,
+                        &cursor_visible_blink,
+                        cursor_idle_timeout_ns,
+                    );
                 }
             }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -474,6 +474,11 @@ fn handleBackendEvent(
     write_buf: *[65536]u8,
     write_pending: *usize,
     evloop_fd: i32,
+    cursor_visible_blink: *bool,
+    cursor_blink_active: *bool,
+    last_input_ns: *i128,
+    last_render_ns: *i128,
+    backend_focused: *bool,
 ) bool {
     switch (event.*) {
         .key => |key_ev| {
@@ -530,6 +535,14 @@ fn handleBackendEvent(
             term.all_dirty = true;
         },
         .focus_in => {
+            // Restore blink + input clock so idle-timeout does not stay "stuck" across focus changes.
+            // Mark cursor dirty and drop frame throttle so the first paint after refocus is immediate.
+            backend_focused.* = true;
+            cursor_visible_blink.* = true;
+            cursor_blink_active.* = true;
+            last_input_ns.* = std.time.nanoTimestamp();
+            last_render_ns.* = 0;
+            term.markDirty(term.cursor_x, term.cursor_y);
             if (term.focus_events) {
                 if (!ptyBufferedWrite(pty_ptr, "\x1b[I", write_buf, write_pending, evloop_fd)) {
                     return false;
@@ -537,6 +550,10 @@ fn handleBackendEvent(
             }
         },
         .focus_out => {
+            backend_focused.* = false;
+            cursor_blink_active.* = false;
+            cursor_visible_blink.* = true;
+            term.markDirty(term.cursor_x, term.cursor_y);
             if (term.focus_events) {
                 if (!ptyBufferedWrite(pty_ptr, "\x1b[O", write_buf, write_pending, evloop_fd)) {
                     return false;
@@ -701,6 +718,10 @@ pub fn main() !void {
     var mod_state: input.Modifiers = .{};
     var pty_buf: [config.pty_buf_size]u8 = undefined;
     var cursor_visible_blink = true;
+    var cursor_blink_active = true; // false after idle timeout — stops blink rendering
+    // false while unfocused: skip cursor timer toggles (avoids stale idle blink + extra wakeups)
+    var backend_focused = true;
+    var last_input_ns: i128 = std.time.nanoTimestamp();
     var prev_cursor_x: u32 = 0;
     var prev_cursor_y: u32 = 0;
     var write_buf: [65536]u8 = undefined;
@@ -784,9 +805,25 @@ pub fn main() !void {
                         // Read timer to acknowledge
                         var exp: u64 = 0;
                         _ = std.posix.read(timer_fd, std.mem.asBytes(&exp)) catch {};
-                        cursor_visible_blink = !cursor_visible_blink;
-                        // Mark cursor cell dirty for redraw
-                        term.markDirty(term.cursor_x, term.cursor_y);
+                        if (!backend_focused) {
+                            // Unfocused: do not toggle cursor or mark dirty (compositor may throttle us anyway).
+                            continue;
+                        }
+                        // Stop blinking after 5 seconds of no input (like other terminals).
+                        // This avoids continuous rendering during idle, which can trigger
+                        // XCB connection issues and wastes CPU/GPU.
+                        const idle_ns = loop_now - last_input_ns;
+                        if (idle_ns > 5_000_000_000) {
+                            if (cursor_blink_active) {
+                                cursor_blink_active = false;
+                                cursor_visible_blink = true; // show cursor solid
+                                term.markDirty(term.cursor_x, term.cursor_y);
+                            }
+                        } else {
+                            cursor_blink_active = true;
+                            cursor_visible_blink = !cursor_visible_blink;
+                            term.markDirty(term.cursor_x, term.cursor_y);
+                        }
                     },
                     @intFromEnum(EpollTag.backend) => {
                         // Backend events (X11, Wayland or macOS)
@@ -804,12 +841,16 @@ pub fn main() !void {
                             while (drain < 8192) : (drain += 1) {
                                 const event = backend.pollEvents() orelse break;
                                 if (event == .key or event == .text or event == .paste) had_input = true;
-                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
+                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
                                     running = false;
                                     break;
                                 }
                             }
-                            if (had_input) cursor_visible_blink = true;
+                            if (had_input) {
+                                cursor_visible_blink = true;
+                                cursor_blink_active = true;
+                                last_input_ns = loop_now;
+                            }
                         }
                     },
                     else => {
@@ -846,7 +887,11 @@ pub fn main() !void {
                                     },
                                 }
                             }
-                            if (had_input) cursor_visible_blink = true;
+                            if (had_input) {
+                                cursor_visible_blink = true;
+                                cursor_blink_active = true;
+                                last_input_ns = loop_now;
+                            }
                         }
                     },
                 }
@@ -890,12 +935,16 @@ pub fn main() !void {
                             var had_input = false;
                             while (backend.pollEvents()) |event| {
                                 if (event == .key or event == .text or event == .paste) had_input = true;
-                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
+                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
                                     running = false;
                                     break;
                                 }
                             }
-                            if (had_input) cursor_visible_blink = true;
+                            if (had_input) {
+                                cursor_visible_blink = true;
+                                cursor_blink_active = true;
+                                last_input_ns = loop_now;
+                            }
                         }
                     }
                 } else if (kev.filter == std.c.EVFILT.WRITE) {
@@ -907,8 +956,21 @@ pub fn main() !void {
                 } else if (kev.filter == std.c.EVFILT.SIGNAL) {
                     running = handleSignal(-1, @intCast(kev.ident), &backend);
                 } else if (kev.filter == std.c.EVFILT.TIMER) {
-                    cursor_visible_blink = !cursor_visible_blink;
-                    term.markDirty(term.cursor_x, term.cursor_y);
+                    if (!backend_focused) {
+                        continue;
+                    }
+                    const idle_ns = loop_now - last_input_ns;
+                    if (idle_ns > 5_000_000_000) {
+                        if (cursor_blink_active) {
+                            cursor_blink_active = false;
+                            cursor_visible_blink = true;
+                            term.markDirty(term.cursor_x, term.cursor_y);
+                        }
+                    } else {
+                        cursor_blink_active = true;
+                        cursor_visible_blink = !cursor_visible_blink;
+                        term.markDirty(term.cursor_x, term.cursor_y);
+                    }
                 }
             }
 
@@ -918,7 +980,7 @@ pub fn main() !void {
             // never appears because Cocoa callbacks never fire.
             if (config.backend == .macos) {
                 while (backend.pollEvents()) |event| {
-                    if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd)) {
+                    if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
                         running = false;
                         break;
                     }


### PR DESCRIPTION
## **User description**
## 概要
ウィンドウが非アクティブのあとフォーカスを取り戻したとき、カーソルが点滅しない・最初の反応が遅く感じる問題を修正します。

## 原因
- 5秒アイドルで点滅が止まった状態のまま `focus_in` で `last_input_ns` と点滅状態を復帰していなかった
- フォーカス直後に dirty が立たず、再描画が PTY 出力やキー入力まで遅れることがあった
- 非フォーカス中も 500ms タイマーで点滅処理が走り得た

## 変更
- `focus_in`: 点滅・入力時刻のリセット、カーソル dirty、`last_render_ns = 0` で即時描画
- `focus_out`: 点滅停止・表示は固定、`backend_focused` でタイマー側の toggle をスキップ
- `handleBackendEvent` にカーソル／フォーカス用ポインタを渡す

## 検証
- `zig build` / `zig build test` 通過

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Restore cursor blinking and immediate redraw when a window regains focus

### What Changed
- When the window regains focus, the cursor now starts blinking again and the current cursor position is redrawn right away
- While the window is unfocused, cursor blinking pauses instead of continuing in the background
- After about 5 seconds without input, blinking stops and the cursor stays solid until the next keypress or paste

### Impact
`✅ Clearer cursor state after switching back to the app`
`✅ Faster response after refocusing the window`
`✅ Less background redraw during idle time`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ユーザー入力（キー入力・テキスト貼り付け等）でカーソルの点滅状態が即座にリセットされ、カーソルが確実に表示されます。
  * フォーカス復帰時にカーソル表示が更新され、見た目が即座に反映されます。

* **バグ修正**
  * ウィンドウがフォーカスを失うとカーソルの点滅が無効化されます。
  * 5秒以上入力がない場合、カーソルが点滅ではなく常時表示に切り替わります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->