### PR TITLE
fix: 長時間利用後の入力詰まりを防ぐため backend イベントを毎ループ排出

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -607,6 +607,30 @@ fn handleBackendEvent(
     return true;
 }
 
+fn drainBackendEvents(
+    term: *Term,
+    pty_ptr: *Pty,
+    backend: *Backend,
+    write_buf: *[65536]u8,
+    write_pending: *usize,
+    evloop_fd: i32,
+    cursor_visible_blink: *bool,
+    cursor_blink_active: *bool,
+    last_input_ns: *i128,
+    last_render_ns: *i128,
+    backend_focused: *bool,
+    max_events: u32,
+) bool {
+    var drain: u32 = 0;
+    while (drain < max_events) : (drain += 1) {
+        const event = backend.pollEvents() orelse break;
+        if (!handleBackendEvent(&event, term, pty_ptr, backend, write_buf, write_pending, evloop_fd, cursor_visible_blink, cursor_blink_active, last_input_ns, last_render_ns, backend_focused)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // =============================================================================
 // Main
 // =============================================================================
@@ -798,6 +822,16 @@ pub fn main() !void {
         } else -1;
 
         if (is_linux) {
+            // X11/Wayland/macos backends can buffer events internally even when their
+            // fd is no longer readable. Drain a bounded amount every loop so input
+            // never appears "stuck" waiting for unrelated socket traffic.
+            if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
+                if (!drainBackendEvents(&term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused, 8192)) {
+                    running = false;
+                    continue;
+                }
+            }
+
             // ---- Linux epoll dispatch ----
             var events: [16]linux.epoll_event = undefined;
             const n_raw = linux.epoll_wait(evloop_fd, &events, events.len, event_timeout);
@@ -857,22 +891,10 @@ pub fn main() !void {
                     },
                     @intFromEnum(EpollTag.backend) => {
                         // Backend events (X11, Wayland or macOS)
-                        // Drain pollEvents until the backend queue is empty (same as
-                        // the macOS kqueue path). On Linux+X11, libxcb often reads the
-                        // whole socket into an internal queue; if we stop after a fixed
-                        // number of delivered events while messages remain, the FD is
-                        // no longer readable and epoll will not wake again — input
-                        // appears stuck or very laggy until unrelated X traffic arrives.
-                        // Cap avoids infinite loops if a backend misbehaves; 8k is far
-                        // above normal bursts but still bounded for timer/signal latency.
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
-                            var drain: u32 = 0;
-                            while (drain < 8192) : (drain += 1) {
-                                const event = backend.pollEvents() orelse break;
-                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
-                                    running = false;
-                                    break;
-                                }
+                            if (!drainBackendEvents(&term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused, 8192)) {
+                                running = false;
+                                break;
                             }
                         }
                     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Claude Code を長時間利用した際に、入力が受け付けられなくなる/極端に遅延する問題を修正しました。

原因は Linux のイベントループで `EpollTag.backend` が来た時だけ backend の内部キューを排出していたことです。X11/Wayland 側は一度の socket read で内部キューに大量イベントを保持するため、FD が非 readable になると epoll が再通知せず、未処理イベントが残って入力が詰まることがありました。

## 変更内容
- `src/main.zig` に `drainBackendEvents(...)` ヘルパーを追加
- Linux ループの先頭で、`x11/wayland/macos` backend の内部イベントを毎イテレーションで上限付き（8192件）で排出
- 既存の `EpollTag.backend` 分岐でも同じヘルパーを利用して重複ロジックを整理

## 期待効果
- backend FD が再通知されない状況でも、内部キューが取り残されず入力停止が起きにくくなる
- 長時間運用時の入力遅延・ハング様症状を解消

## 検証
- `zig build test`（Zig 0.15.2 バイナリをローカル取得して実行）
- `zig build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe88b6e6-0b7d-4349-b1fd-779ed300cf1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe88b6e6-0b7d-4349-b1fd-779ed300cf1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 複数のプラットフォーム（Linux、X11、Wayland、macOS）でのバックエンドイベント処理ロジックを最適化し、イベント処理の効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->