### PR TITLE
Fix input freeze and IME loss during long sessions

### DIFF
--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -16,6 +16,31 @@ const clipboard_mod = @import("wayland/clipboard.zig");
 // Event types — mirrors x11.zig's Event union
 // ============================================================================
 
+pub const MouseEvent = struct {
+    x: u32, // pixel x
+    y: u32, // pixel y
+    button: Button,
+    action: Action,
+    modifiers: input_mod.Modifiers,
+
+    pub const Button = enum(u3) {
+        left = 0,
+        middle = 1,
+        right = 2,
+        none = 3,
+        wheel_up = 4,
+        wheel_down = 5,
+        wheel_left = 6,
+        wheel_right = 7,
+    };
+
+    pub const Action = enum(u2) {
+        press,
+        release,
+        motion,
+    };
+};
+
 pub const Event = union(enum) {
     key: KeyEvent,
     text: TextEvent,
@@ -25,6 +50,7 @@ pub const Event = union(enum) {
     close: void,
     focus_in: void,
     focus_out: void,
+    mouse: MouseEvent,
 };
 
 pub const PasteEvent = struct {

--- a/src/backend/wayland.zig
+++ b/src/backend/wayland.zig
@@ -161,6 +161,9 @@ pub const WaylandBackend = struct {
     cursor_shape_device_id: u32 = 0,
     fallback_cursor_surface_id: u32 = 0, // reuse across pointer.enter events
     pointer_serial: u32 = 0,
+    pointer_x: u32 = 0, // last known pixel x
+    pointer_y: u32 = 0, // last known pixel y
+    pointer_button: Event.MouseEvent.Button = .none, // currently held button
     repeat_registered: bool = false,
 
     // IME
@@ -1142,6 +1145,11 @@ pub const WaylandBackend = struct {
                 var pos: usize = 0;
                 const serial = wire.getUint(payload, &pos);
                 self.pointer_serial = serial;
+                _ = wire.getUint(payload, &pos); // surface
+                const x_fixed_e: i32 = @bitCast(wire.getUint(payload, &pos));
+                const y_fixed_e: i32 = @bitCast(wire.getUint(payload, &pos));
+                self.pointer_x = @intCast(@max(0, x_fixed_e >> 8));
+                self.pointer_y = @intCast(@max(0, y_fixed_e >> 8));
 
                 // Set cursor shape
                 if (self.cursor_shape_device_id != 0) {
@@ -1154,11 +1162,78 @@ pub const WaylandBackend = struct {
                 }
                 self.conn.flush() catch {};
             },
+            seat_mod.WL_POINTER_EVENT_LEAVE => {
+                self.pointer_button = .none;
+            },
+            seat_mod.WL_POINTER_EVENT_MOTION => {
+                // Payload: time(u32) + x(fixed) + y(fixed)
+                var pos: usize = 0;
+                _ = wire.getUint(payload, &pos); // time
+                const x_fixed: i32 = @bitCast(wire.getUint(payload, &pos));
+                const y_fixed: i32 = @bitCast(wire.getUint(payload, &pos));
+                // wl_fixed_t: signed 24.8 format — clamp negative to 0
+                self.pointer_x = @intCast(@max(0, x_fixed >> 8));
+                self.pointer_y = @intCast(@max(0, y_fixed >> 8));
+
+                self.queueEvent(.{ .mouse = .{
+                    .x = self.pointer_x,
+                    .y = self.pointer_y,
+                    .button = self.pointer_button,
+                    .action = .motion,
+                    .modifiers = .{},
+                } });
+            },
             seat_mod.WL_POINTER_EVENT_BUTTON => {
                 // Payload: serial(u32) + time(u32) + button(u32) + state(u32)
                 var pos: usize = 0;
                 const serial = wire.getUint(payload, &pos);
                 self.pointer_serial = serial;
+                _ = wire.getUint(payload, &pos); // time
+                const linux_button = wire.getUint(payload, &pos);
+                const state = wire.getUint(payload, &pos);
+
+                const button: Event.MouseEvent.Button = switch (linux_button) {
+                    0x110 => .left, // BTN_LEFT
+                    0x111 => .right, // BTN_RIGHT
+                    0x112 => .middle, // BTN_MIDDLE
+                    else => return,
+                };
+                const action: Event.MouseEvent.Action = if (state != 0) .press else .release;
+
+                // Track button state for motion events
+                if (action == .press) {
+                    self.pointer_button = button;
+                } else {
+                    self.pointer_button = .none;
+                }
+
+                self.queueEvent(.{ .mouse = .{
+                    .x = self.pointer_x,
+                    .y = self.pointer_y,
+                    .button = button,
+                    .action = action,
+                    .modifiers = .{}, // Will get modifiers from keyboard state if available
+                } });
+            },
+            seat_mod.WL_POINTER_EVENT_AXIS => {
+                // Payload: time(u32) + axis(u32) + value(fixed)
+                var pos: usize = 0;
+                _ = wire.getUint(payload, &pos); // time
+                const axis = wire.getUint(payload, &pos);
+                const value_fixed: i32 = @bitCast(wire.getUint(payload, &pos));
+                // axis 0 = vertical, 1 = horizontal
+                // value > 0 = down/right, < 0 = up/left
+                const button: Event.MouseEvent.Button = if (axis == 0)
+                    (if (value_fixed > 0) .wheel_down else .wheel_up)
+                else
+                    (if (value_fixed > 0) .wheel_right else .wheel_left);
+                self.queueEvent(.{ .mouse = .{
+                    .x = self.pointer_x,
+                    .y = self.pointer_y,
+                    .button = button,
+                    .action = .press,
+                    .modifiers = .{},
+                } });
             },
             else => {},
         }

--- a/src/backend/wayland/seat.zig
+++ b/src/backend/wayland/seat.zig
@@ -42,6 +42,8 @@ pub const WL_POINTER_EVENT_ENTER: u16 = 0;
 pub const WL_POINTER_EVENT_LEAVE: u16 = 1;
 pub const WL_POINTER_EVENT_MOTION: u16 = 2;
 pub const WL_POINTER_EVENT_BUTTON: u16 = 3;
+pub const WL_POINTER_EVENT_AXIS: u16 = 4;
+pub const WL_POINTER_EVENT_FRAME: u16 = 5;
 
 // wl_pointer requests
 pub const WL_POINTER_SET_CURSOR: u16 = 0;

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -11,6 +11,31 @@ const c = @cImport({
     @cInclude("xkbcommon/xkbcommon-x11.h");
 });
 
+pub const MouseEvent = struct {
+    x: u32, // pixel x
+    y: u32, // pixel y
+    button: Button,
+    action: Action,
+    modifiers: input_mod.Modifiers,
+
+    pub const Button = enum(u3) {
+        left = 0,
+        middle = 1,
+        right = 2,
+        none = 3,
+        wheel_up = 4,
+        wheel_down = 5,
+        wheel_left = 6,
+        wheel_right = 7,
+    };
+
+    pub const Action = enum(u2) {
+        press,
+        release,
+        motion,
+    };
+};
+
 pub const Event = union(enum) {
     key: KeyEvent,
     text: TextEvent,
@@ -20,6 +45,7 @@ pub const Event = union(enum) {
     close: void,
     focus_in: void,
     focus_out: void,
+    mouse: MouseEvent,
 };
 
 pub const PasteEvent = struct {
@@ -64,6 +90,9 @@ pub const X11Backend = struct {
     shm_id: [2]c_int,
     buffers: [2][]u8,
     buf_idx: u1 = 0, // current back buffer index
+    shm_busy: bool = false, // true while X server is reading the front buffer
+    shm_busy_ns: i128 = 0, // timestamp when shm_busy was set (for timeout fallback)
+    shm_event_base: u8 = 0, // SHM extension first_event for completion detection
     // Dimensions
     width: u32,
     height: u32,
@@ -307,7 +336,15 @@ pub const X11Backend = struct {
             );
         }
 
-        // 10. Map window and flush
+        // 10. Query SHM extension first_event for completion events
+        var shm_event_base: u8 = 0;
+        if (c.xcb_get_extension_data(connection, &c.xcb_shm_id)) |ext| {
+            if (ext.*.present != 0) {
+                shm_event_base = ext.*.first_event;
+            }
+        }
+
+        // 11. Map window and flush
         _ = c.xcb_map_window(connection, window);
         _ = c.xcb_flush(connection);
 
@@ -327,6 +364,7 @@ pub const X11Backend = struct {
             .utf8_string_atom = utf8_string_atom,
             .zt_paste_atom = zt_paste_atom,
             .net_wm_name_atom = net_wm_name_atom,
+            .shm_event_base = shm_event_base,
             .screen_id = screen_num,
             .embed_parent = embed_window,
             .xembed_atom = xembed_atom,
@@ -591,10 +629,14 @@ pub const X11Backend = struct {
         }
     }
 
-    fn disconnectedCallback(_: ?*c.xcb_xim_t, user_data: ?*anyopaque) callconv(.c) void {
+    fn disconnectedCallback(xim: ?*c.xcb_xim_t, user_data: ?*anyopaque) callconv(.c) void {
         const self: *Self = @ptrCast(@alignCast(user_data));
         self.xim_connected = false;
         self.xic = 0;
+        // Attempt to reconnect — ximOpenCallback will restore xim_connected
+        if (xim) |x| {
+            _ = c.xcb_xim_open(x, ximOpenCallback, true, user_data);
+        }
     }
 
     pub fn deinit(self: *Self) void {
@@ -727,6 +769,15 @@ pub const X11Backend = struct {
     pub fn present(self: *Self) void {
         if (self.dirty_y_min > self.dirty_y_max) return; // nothing to present
 
+        // Skip if X server is still reading the previous front buffer.
+        // Keep dirty state so the next frame will include these regions.
+        // Timeout after 100ms in case the SHM_COMPLETION event was lost.
+        if (self.shm_busy) {
+            const now = std.time.nanoTimestamp();
+            if (now - self.shm_busy_ns < 100_000_000) return;
+            self.shm_busy = false;
+        }
+
         const front = self.buf_idx;
         const y_start = self.dirty_y_min;
         const y_end = @min(self.dirty_y_max + 1, self.height);
@@ -747,10 +798,12 @@ pub const X11Backend = struct {
             @intCast(y_start),
             self.screen.*.root_depth,
             c.XCB_IMAGE_FORMAT_Z_PIXMAP,
-            0,
+            1, // send_event=1: X server sends SHM_COMPLETION when done reading
             self.shm_seg[front],
             shm_offset,
         );
+        self.shm_busy = true;
+        self.shm_busy_ns = std.time.nanoTimestamp();
 
         // Lazy-init second buffer on first present, then swap
         const back: u1 = front ^ 1;
@@ -851,6 +904,10 @@ pub const X11Backend = struct {
                 // local XKB instead of being forwarded into a dead IM server.
                 self.xim_connected = false;
                 self.xic = 0;
+                // Attempt to reconnect — ximOpenCallback will restore xim_connected
+                if (self.xim) |xim| {
+                    _ = c.xcb_xim_open(xim, ximOpenCallback, true, @ptrCast(self));
+                }
             }
         }
 
@@ -1188,7 +1245,13 @@ pub const X11Backend = struct {
                     }
                     return .focus_out;
                 },
-                else => continue, // Skip unhandled events (ReparentNotify, MapNotify, etc.)
+                else => {
+                    // SHM_COMPLETION: X server finished reading the front buffer
+                    if (self.shm_event_base != 0 and event_type == self.shm_event_base + c.XCB_SHM_COMPLETION) {
+                        self.shm_busy = false;
+                    }
+                    continue; // Skip unhandled events (ReparentNotify, MapNotify, etc.)
+                },
             }
         } // while (true)
     }

--- a/src/backend/x11.zig
+++ b/src/backend/x11.zig
@@ -182,7 +182,10 @@ pub const X11Backend = struct {
             c.XCB_EVENT_MASK_KEY_RELEASE |
             c.XCB_EVENT_MASK_STRUCTURE_NOTIFY |
             c.XCB_EVENT_MASK_EXPOSURE |
-            c.XCB_EVENT_MASK_FOCUS_CHANGE;
+            c.XCB_EVENT_MASK_FOCUS_CHANGE |
+            c.XCB_EVENT_MASK_BUTTON_PRESS |
+            c.XCB_EVENT_MASK_BUTTON_RELEASE |
+            c.XCB_EVENT_MASK_BUTTON_MOTION;
         const parent = if (embed_window != 0) embed_window else screen.*.root;
         const values = [_]u32{ 0, event_mask }; // back_pixel=black, event_mask
         _ = c.xcb_create_window(
@@ -1244,6 +1247,68 @@ pub const X11Backend = struct {
                         }
                     }
                     return .focus_out;
+                },
+                c.XCB_BUTTON_PRESS => {
+                    const btn_ev: *c.xcb_button_press_event_t = @ptrCast(@alignCast(event));
+                    // Skip unknown buttons (> 7)
+                    if (btn_ev.*.detail == 0 or btn_ev.*.detail > 7) continue;
+                    const mods = xcbStateToMods(btn_ev.*.state);
+                    const button: MouseEvent.Button = switch (btn_ev.*.detail) {
+                        1 => .left,
+                        2 => .middle,
+                        3 => .right,
+                        4 => .wheel_up,
+                        5 => .wheel_down,
+                        6 => .wheel_left,
+                        7 => .wheel_right,
+                        else => unreachable,
+                    };
+                    return .{ .mouse = .{
+                        .x = @intCast(@max(0, btn_ev.*.event_x)),
+                        .y = @intCast(@max(0, btn_ev.*.event_y)),
+                        .button = button,
+                        .action = .press,
+                        .modifiers = mods,
+                    } };
+                },
+                c.XCB_BUTTON_RELEASE => {
+                    const btn_ev: *c.xcb_button_release_event_t = @ptrCast(@alignCast(event));
+                    // Ignore wheel button releases (4-7)
+                    if (btn_ev.*.detail >= 4) continue;
+                    const mods = xcbStateToMods(btn_ev.*.state);
+                    const button: MouseEvent.Button = switch (btn_ev.*.detail) {
+                        1 => .left,
+                        2 => .middle,
+                        3 => .right,
+                        else => continue,
+                    };
+                    return .{ .mouse = .{
+                        .x = @intCast(@max(0, btn_ev.*.event_x)),
+                        .y = @intCast(@max(0, btn_ev.*.event_y)),
+                        .button = button,
+                        .action = .release,
+                        .modifiers = mods,
+                    } };
+                },
+                c.XCB_MOTION_NOTIFY => {
+                    const motion: *c.xcb_motion_notify_event_t = @ptrCast(@alignCast(event));
+                    const mods = xcbStateToMods(motion.*.state);
+                    // Determine which button is held from X11 state bits
+                    const button: MouseEvent.Button = if (motion.*.state & c.XCB_BUTTON_MASK_1 != 0)
+                        .left
+                    else if (motion.*.state & c.XCB_BUTTON_MASK_2 != 0)
+                        .middle
+                    else if (motion.*.state & c.XCB_BUTTON_MASK_3 != 0)
+                        .right
+                    else
+                        .none;
+                    return .{ .mouse = .{
+                        .x = @intCast(@max(0, motion.*.event_x)),
+                        .y = @intCast(@max(0, motion.*.event_y)),
+                        .button = button,
+                        .action = .motion,
+                        .modifiers = mods,
+                    } };
                 },
                 else => {
                     // SHM_COMPLETION: X server finished reading the front buffer

--- a/src/main.zig
+++ b/src/main.zig
@@ -623,7 +623,7 @@ fn handleBackendEvent(
 
             // Shift held → terminal selection (bypass app mouse capture)
             if (mouse_ev.modifiers.shift) {
-                // TODO: terminal selection (Task 5+6)
+                handleTerminalSelection(term, mouse_ev, cx, cy);
                 return true;
             }
 
@@ -637,7 +637,7 @@ fn handleBackendEvent(
                 }
             } else {
                 // No app mouse mode → terminal selection
-                // TODO: terminal selection (Task 5+6)
+                handleTerminalSelection(term, mouse_ev, cx, cy);
             }
         },
         .close => {
@@ -746,6 +746,57 @@ fn encodeMouseEvent(term: *const Term, ev: BackendEvent.MouseEvent, cx: u32, cy:
         },
     }
     return result;
+}
+
+fn handleTerminalSelection(term: *Term, ev: BackendEvent.MouseEvent, cx: u32, cy: u32) void {
+    switch (ev.action) {
+        .press => switch (ev.button) {
+            .left => {
+                // Start new selection
+                term.selection = .{
+                    .start_x = cx,
+                    .start_y = cy,
+                    .end_x = cx,
+                    .end_y = cy,
+                    .active = true,
+                };
+                // Mark screen dirty for selection highlight
+                const total = @as(usize, term.cols) * @as(usize, term.rows);
+                term.markDirtyRange(.{ .start = 0, .end = total });
+            },
+            .wheel_up, .wheel_down => {
+                // When no app captures mouse and in alt screen,
+                // translate wheel to arrow keys for less/man etc.
+                // TODO: scrollback when implemented
+            },
+            else => {},
+        },
+        .motion => {
+            if (term.selection) |*sel| {
+                if (sel.active) {
+                    sel.end_x = cx;
+                    sel.end_y = cy;
+                    // Mark dirty for selection update
+                    const total = @as(usize, term.cols) * @as(usize, term.rows);
+                    term.markDirtyRange(.{ .start = 0, .end = total });
+                }
+            }
+        },
+        .release => {
+            if (ev.button == .left) {
+                if (term.selection) |*sel| {
+                    sel.active = false;
+                    // If start == end, clear selection (was just a click)
+                    if (sel.start_x == sel.end_x and sel.start_y == sel.end_y) {
+                        term.selection = null;
+                    }
+                    // TODO: copy to clipboard (Task 7)
+                }
+                const total = @as(usize, term.cols) * @as(usize, term.rows);
+                term.markDirtyRange(.{ .start = 0, .end = total });
+            }
+        },
+    }
 }
 
 fn encodeUtf8Coord(val: u32, buf: []u8) u8 {
@@ -1003,6 +1054,11 @@ pub fn main() !void {
                                     break;
                                 }
                                 bytes_since_render += bytes_read;
+                                // Clear selection when terminal content changes
+                                if (term.selection != null) {
+                                    term.selection = null;
+                                    term.all_dirty = true;
+                                }
                                 vt.feedBulk(&parser, pty_buf[0..bytes_read], &term, pty.master_fd);
                                 // Flush VT responses after each chunk to prevent overflow
                                 if (term.vt_response_len > 0) {
@@ -1126,6 +1182,11 @@ pub fn main() !void {
                                 break;
                             }
                             bytes_since_render += bytes_read;
+                            // Clear selection when terminal content changes
+                            if (term.selection != null) {
+                                term.selection = null;
+                                term.all_dirty = true;
+                            }
                             vt.feedBulk(&parser, pty_buf[0..bytes_read], &term, pty.master_fd);
                             // Flush VT responses after each chunk to prevent overflow
                             if (term.vt_response_len > 0) {
@@ -1193,6 +1254,11 @@ pub fn main() !void {
                 }
                 bytes_since_render += extra;
                 extra_total += extra;
+                // Clear selection when terminal content changes
+                if (term.selection != null) {
+                    term.selection = null;
+                    term.all_dirty = true;
+                }
                 vt.feedBulk(&parser, pty_buf[0..extra], &term, pty.master_fd);
                 // Flush VT responses after each chunk to prevent overflow
                 if (term.vt_response_len > 0) {
@@ -1342,6 +1408,18 @@ pub fn main() !void {
                     const tmp_rgb = fg_rgb;
                     fg_rgb = bg_rgb;
                     bg_rgb = tmp_rgb;
+                }
+
+                // Selection highlight: invert fg/bg
+                if (term.selection) |sel| {
+                    if (sel.contains(x, y)) {
+                        const tmp_idx2 = render_cell.fg;
+                        render_cell.fg = render_cell.bg;
+                        render_cell.bg = tmp_idx2;
+                        const tmp_rgb2 = fg_rgb;
+                        fg_rgb = bg_rgb;
+                        bg_rgb = tmp_rgb2;
+                    }
                 }
 
                 // Skip per-cell bg fill when global fill was applied, UNLESS:

--- a/src/main.zig
+++ b/src/main.zig
@@ -748,6 +748,39 @@ fn encodeMouseEvent(term: *const Term, ev: BackendEvent.MouseEvent, cx: u32, cy:
     return result;
 }
 
+fn extractSelectionText(term: *const Term, buf: []u8) []const u8 {
+    const sel = term.selection orelse return &.{};
+    const o = sel.ordered();
+    var pos: usize = 0;
+
+    var y = o.sy;
+    while (y <= o.ey) : (y += 1) {
+        const start_x = if (y == o.sy) o.sx else 0;
+        const end_x = if (y == o.ey) o.ex else term.cols - 1;
+
+        const phys_row = term.row_map[y];
+        const row_base = @as(usize, phys_row) * @as(usize, term.cols);
+        const row_cells = term.cells[row_base..][0..term.cols];
+
+        var x = start_x;
+        while (x <= end_x) : (x += 1) {
+            const ch = row_cells[x].char;
+            if (ch == 0 or row_cells[x].attrs.wide_dummy) continue;
+            var encode_buf: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(ch, &encode_buf) catch continue;
+            if (pos + len > buf.len) break;
+            @memcpy(buf[pos..][0..len], encode_buf[0..len]);
+            pos += len;
+        }
+        // Add newline between rows (not after last)
+        if (y < o.ey and pos < buf.len) {
+            buf[pos] = '\n';
+            pos += 1;
+        }
+    }
+    return buf[0..pos];
+}
+
 fn handleTerminalSelection(term: *Term, ev: BackendEvent.MouseEvent, cx: u32, cy: u32) void {
     switch (ev.action) {
         .press => switch (ev.button) {
@@ -789,8 +822,14 @@ fn handleTerminalSelection(term: *Term, ev: BackendEvent.MouseEvent, cx: u32, cy
                     // If start == end, clear selection (was just a click)
                     if (sel.start_x == sel.end_x and sel.start_y == sel.end_y) {
                         term.selection = null;
+                    } else {
+                        // Copy selection text to clipboard
+                        var clipboard_buf: [16384]u8 = undefined;
+                        const text = extractSelectionText(term, &clipboard_buf);
+                        if (text.len > 0) {
+                            dispatchClipboardCopy(text);
+                        }
                     }
-                    // TODO: copy to clipboard (Task 7)
                 }
                 const total = @as(usize, term.cols) * @as(usize, term.rows);
                 term.markDirtyRange(.{ .start = 0, .end = total });

--- a/src/main.zig
+++ b/src/main.zig
@@ -600,6 +600,9 @@ fn handleBackendEvent(
                 }
             }
         },
+        .mouse => {
+            // TODO: implement mouse dispatch
+        },
         .close => {
             return false;
         },
@@ -777,11 +780,11 @@ pub fn main() !void {
         // Tier 0: <64KB  → frame_min_ns (default 8ms = 120fps)
         // Tier 1: 64KB+  → frame_min_ns * 2 (default 16ms = 60fps)
         // Tier 2: 256KB+ → frame_min_ns * 8 (default 64ms = ~15fps)
-        // Tier 3: 1MB+   → frame_min_ns * 24 (default 192ms = ~5fps)
+        // Tier 3: 1MB+   → capped at 64ms to keep input responsive
         const effective_frame_ns: i128 = if (config.frame_min_ns == 0)
             0
         else if (bytes_since_render > 1_048_576)
-            @as(i128, config.frame_min_ns) * 24
+            @min(@as(i128, config.frame_min_ns) * 24, 64_000_000)
         else if (bytes_since_render > 262_144)
             @as(i128, config.frame_min_ns) * 8
         else if (bytes_since_render > 65_536)
@@ -796,6 +799,16 @@ pub fn main() !void {
             const remaining_ms = @divFloor(effective_frame_ns - elapsed, 1_000_000);
             break :blk @intCast(@max(remaining_ms, 1));
         } else -1;
+
+        // Proactively flush pending writes before blocking on events.
+        // This ensures buffered keystrokes reach the child ASAP, preventing
+        // input starvation when heavy output keeps the write buffer occupied.
+        if (write_pending > 0) {
+            if (!ptyFlushPending(&pty, &write_buf, &write_pending, evloop_fd)) {
+                running = false;
+                continue;
+            }
+        }
 
         if (is_linux) {
             // ---- Linux epoll dispatch ----
@@ -836,6 +849,14 @@ pub fn main() !void {
                                 }
                                 bytes_since_render += bytes_read;
                                 vt.feedBulk(&parser, pty_buf[0..bytes_read], &term, pty.master_fd);
+                                // Flush VT responses after each chunk to prevent overflow
+                                if (term.vt_response_len > 0) {
+                                    if (!ptyBufferedWrite(&pty, term.vt_response_buf[0..term.vt_response_len], &write_buf, &write_pending, evloop_fd)) {
+                                        running = false;
+                                        break;
+                                    }
+                                    term.vt_response_len = 0;
+                                }
                             }
                         }
                     },
@@ -951,6 +972,14 @@ pub fn main() !void {
                             }
                             bytes_since_render += bytes_read;
                             vt.feedBulk(&parser, pty_buf[0..bytes_read], &term, pty.master_fd);
+                            // Flush VT responses after each chunk to prevent overflow
+                            if (term.vt_response_len > 0) {
+                                if (!ptyBufferedWrite(&pty, term.vt_response_buf[0..term.vt_response_len], &write_buf, &write_pending, evloop_fd)) {
+                                    running = false;
+                                    break;
+                                }
+                                term.vt_response_len = 0;
+                            }
                         }
                     } else if (kev.udata == @intFromEnum(KqueueTag.backend)) {
                         // Backend events (X11, Wayland or macOS)
@@ -998,10 +1027,10 @@ pub fn main() !void {
         }
 
         // Extra PTY drain: data may have arrived during event processing.
-        // Capped at pty_buf_size*4 to prevent render starvation from infinite producers (yes, cat /dev/urandom).
+        // Capped at pty_buf_size to keep event loop responsive for input.
         if (running) {
             var extra_total: usize = 0;
-            while (extra_total < config.pty_buf_size * 4) {
+            while (extra_total < config.pty_buf_size) {
                 const extra = pty.read(&pty_buf) catch break;
                 if (extra == 0) {
                     running = false;
@@ -1010,6 +1039,14 @@ pub fn main() !void {
                 bytes_since_render += extra;
                 extra_total += extra;
                 vt.feedBulk(&parser, pty_buf[0..extra], &term, pty.master_fd);
+                // Flush VT responses after each chunk to prevent overflow
+                if (term.vt_response_len > 0) {
+                    if (!ptyBufferedWrite(&pty, term.vt_response_buf[0..term.vt_response_len], &write_buf, &write_pending, evloop_fd)) {
+                        running = false;
+                        break;
+                    }
+                    term.vt_response_len = 0;
+                }
             }
         }
 
@@ -1068,14 +1105,6 @@ pub fn main() !void {
                     backend.updateTitle("zt " ++ config.version);
                 }
             }
-        }
-
-        // Update IME cursor position (X11 and Wayland)
-        if (@hasDecl(Backend, "updateImeCursorPos")) {
-            backend.updateImeCursorPos(
-                term.cursor_x * config.cell_width,
-                (term.cursor_y + 1) * config.cell_height,
-            );
         }
 
         // Render dirty cells — skip entirely if nothing changed
@@ -1185,6 +1214,14 @@ pub fn main() !void {
         term.clearDirty();
         last_render_ns = std.time.nanoTimestamp();
         bytes_since_render = 0;
+
+        // Update IME cursor position only on render (avoids XIM request storms during heavy output)
+        if (@hasDecl(Backend, "updateImeCursorPos")) {
+            backend.updateImeCursorPos(
+                term.cursor_x * config.cell_width,
+                (term.cursor_y + 1) * config.cell_height,
+            );
+        }
 
         backend.present();
         backend.flush();

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,6 +28,17 @@ const BackendEvent = switch (config.backend) {
     .fbdev => void,
 };
 
+const MouseButton = if (config.backend == .fbdev) enum { none } else BackendEvent.MouseEvent.Button;
+
+const EncodedMouse = struct {
+    data: [32]u8 = undefined,
+    len: u8 = 0,
+
+    fn slice(self: *const EncodedMouse) []const u8 {
+        return self.data[0..self.len];
+    }
+};
+
 // Embed font at comptime
 // Large fonts use pre-compiled blob (bdf2blob.py) to avoid slow comptime parsing
 const FontType = font_mod.FontBlob(@embedFile("fonts/ufo-nf.bin"));
@@ -516,6 +527,7 @@ fn handleBackendEvent(
     last_input_ns: *i128,
     last_render_ns: *i128,
     backend_focused: *bool,
+    last_pressed_button: *MouseButton,
 ) bool {
     switch (event.*) {
         .key => |key_ev| {
@@ -600,14 +612,156 @@ fn handleBackendEvent(
                 }
             }
         },
-        .mouse => {
-            // TODO: implement mouse dispatch
+        .mouse => |mouse_ev| {
+            refreshCursorBlinkOnUserInput(cursor_visible_blink, cursor_blink_active, last_input_ns);
+
+            // Pixel → cell coordinate conversion
+            const col: u32 = mouse_ev.x / config.cell_width;
+            const row: u32 = mouse_ev.y / config.cell_height;
+            const cx = @min(col, term.cols -| 1);
+            const cy = @min(row, term.rows -| 1);
+
+            // Shift held → terminal selection (bypass app mouse capture)
+            if (mouse_ev.modifiers.shift) {
+                // TODO: terminal selection (Task 5+6)
+                return true;
+            }
+
+            // App captures mouse → encode VT sequence
+            if (term.mouse_mode != .none) {
+                const seq = encodeMouseEvent(term, mouse_ev, cx, cy, last_pressed_button);
+                if (seq.len > 0) {
+                    if (!ptyBufferedWrite(pty_ptr, seq.slice(), write_buf, write_pending, evloop_fd)) {
+                        return false;
+                    }
+                }
+            } else {
+                // No app mouse mode → terminal selection
+                // TODO: terminal selection (Task 5+6)
+            }
         },
         .close => {
             return false;
         },
     }
     return true;
+}
+
+fn encodeMouseEvent(term: *const Term, ev: BackendEvent.MouseEvent, cx: u32, cy: u32, last_btn: *MouseButton) EncodedMouse {
+    // Filter events based on mouse mode
+    switch (term.mouse_mode) {
+        .none => return .{},
+        .x10 => {
+            if (ev.action != .press) return .{};
+        },
+        .normal => {
+            if (ev.action == .motion) return .{};
+        },
+        .button => {
+            // ?1002: motion only while button held (drag)
+            if (ev.action == .motion and ev.button == .none) return .{};
+        },
+        .any => {}, // report everything
+    }
+
+    // Track pressed button for SGR release
+    if (ev.action == .press and ev.button != .none) {
+        last_btn.* = ev.button;
+    }
+
+    // Build button byte
+    var btn: u8 = switch (ev.action) {
+        .release => switch (term.mouse_encoding) {
+            .sgr => switch (last_btn.*) {
+                .left => 0,
+                .middle => 1,
+                .right => 2,
+                else => 3,
+            },
+            else => 3, // X10/UTF-8/URXVT: generic release
+        },
+        else => switch (ev.button) {
+            .left => 0,
+            .middle => 1,
+            .right => 2,
+            .none => 3,
+            .wheel_up => 64,
+            .wheel_down => 65,
+            .wheel_left => 66,
+            .wheel_right => 67,
+        },
+    };
+
+    if (ev.action == .release) {
+        last_btn.* = .none;
+    }
+
+    // Modifier bits (not for X10 mode)
+    if (term.mouse_mode != .x10) {
+        if (ev.modifiers.shift) btn |= 4;
+        if (ev.modifiers.alt) btn |= 8;
+        if (ev.modifiers.ctrl) btn |= 16;
+    }
+
+    // Motion flag
+    if (ev.action == .motion) btn |= 32;
+
+    var result: EncodedMouse = .{};
+
+    switch (term.mouse_encoding) {
+        .sgr => {
+            // CSI < Pb ; Px ; Py M/m
+            const suffix: u8 = if (ev.action == .release) 'm' else 'M';
+            result.len = @intCast((std.fmt.bufPrint(&result.data, "\x1b[<{d};{d};{d}{c}", .{
+                btn, cx + 1, cy + 1, suffix,
+            }) catch return .{}).len);
+        },
+        .x10 => {
+            // CSI M Cb Cx Cy (max 223)
+            if (cx + 1 > 223 or cy + 1 > 223) return .{};
+            result.data[0] = 0x1b;
+            result.data[1] = '[';
+            result.data[2] = 'M';
+            result.data[3] = btn + 32;
+            result.data[4] = @intCast(cx + 1 + 32);
+            result.data[5] = @intCast(cy + 1 + 32);
+            result.len = 6;
+        },
+        .utf8 => {
+            // Like X10 but coords encoded as UTF-8
+            result.data[0] = 0x1b;
+            result.data[1] = '[';
+            result.data[2] = 'M';
+            result.data[3] = btn + 32;
+            var pos: u8 = 4;
+            pos += encodeUtf8Coord(cx + 1 + 32, result.data[pos..]);
+            pos += encodeUtf8Coord(cy + 1 + 32, result.data[pos..]);
+            result.len = pos;
+        },
+        .urxvt => {
+            // CSI Pb ; Px ; Py M
+            result.len = @intCast((std.fmt.bufPrint(&result.data, "\x1b[{d};{d};{d}M", .{
+                btn + 32, cx + 1, cy + 1,
+            }) catch return .{}).len);
+        },
+    }
+    return result;
+}
+
+fn encodeUtf8Coord(val: u32, buf: []u8) u8 {
+    if (val < 0x80) {
+        buf[0] = @intCast(val);
+        return 1;
+    } else if (val < 0x800) {
+        buf[0] = @intCast(0xC0 | (val >> 6));
+        buf[1] = @intCast(0x80 | (val & 0x3F));
+        return 2;
+    } else {
+        buf[0] = @intCast(0xE0 | (val >> 12));
+        buf[1] = @intCast(0x80 | ((val >> 6) & 0x3F));
+        buf[2] = @intCast(0x80 | (val & 0x3F));
+        return 3;
+    }
 }
 
 // =============================================================================
@@ -764,6 +918,7 @@ pub fn main() !void {
     var cursor_blink_active = true; // false after idle timeout — stops blink rendering
     // false while unfocused: skip cursor timer toggles (avoids stale idle blink + extra wakeups)
     var backend_focused = true;
+    var last_pressed_button: MouseButton = .none;
     var last_input_ns: i128 = std.time.nanoTimestamp();
     const cursor_idle_timeout_ns: i128 = 5 * std.time.ns_per_s;
     var prev_cursor_x: u32 = 0;
@@ -890,7 +1045,7 @@ pub fn main() !void {
                             var drain: u32 = 0;
                             while (drain < 8192) : (drain += 1) {
                                 const event = backend.pollEvents() orelse break;
-                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
+                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused, &last_pressed_button)) {
                                     running = false;
                                     break;
                                 }
@@ -985,7 +1140,7 @@ pub fn main() !void {
                         // Backend events (X11, Wayland or macOS)
                         if (config.backend == .x11 or config.backend == .wayland or config.backend == .macos) {
                             while (backend.pollEvents()) |event| {
-                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
+                                if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused, &last_pressed_button)) {
                                     running = false;
                                     break;
                                 }
@@ -1018,7 +1173,7 @@ pub fn main() !void {
             // never appears because Cocoa callbacks never fire.
             if (config.backend == .macos) {
                 while (backend.pollEvents()) |event| {
-                    if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused)) {
+                    if (!handleBackendEvent(&event, &term, &pty, &backend, &write_buf, &write_pending, evloop_fd, &cursor_visible_blink, &cursor_blink_active, &last_input_ns, &last_render_ns, &backend_focused, &last_pressed_button)) {
                         running = false;
                         break;
                     }

--- a/src/term.zig
+++ b/src/term.zig
@@ -81,6 +81,33 @@ pub const MouseEncoding = enum(u2) {
     urxvt = 3,     // ?1015: CSI Pb;Px;Py M
 };
 
+pub const Selection = struct {
+    start_x: u32,
+    start_y: u32,
+    end_x: u32,
+    end_y: u32,
+    active: bool, // currently dragging
+
+    /// Returns ordered start/end (top-left to bottom-right)
+    pub fn ordered(self: Selection) struct { sx: u32, sy: u32, ex: u32, ey: u32 } {
+        if (self.start_y < self.end_y or (self.start_y == self.end_y and self.start_x <= self.end_x)) {
+            return .{ .sx = self.start_x, .sy = self.start_y, .ex = self.end_x, .ey = self.end_y };
+        } else {
+            return .{ .sx = self.end_x, .sy = self.end_y, .ex = self.start_x, .ey = self.start_y };
+        }
+    }
+
+    /// Check if a cell is within the selection range
+    pub fn contains(self: Selection, x: u32, y: u32) bool {
+        const o = self.ordered();
+        if (y < o.sy or y > o.ey) return false;
+        if (y == o.sy and y == o.ey) return x >= o.sx and x <= o.ex;
+        if (y == o.sy) return x >= o.sx;
+        if (y == o.ey) return x <= o.ex;
+        return true; // middle row
+    }
+};
+
 pub const Term = struct {
     const Self = @This();
 
@@ -194,6 +221,9 @@ pub const Term = struct {
     // Mouse tracking modes (DECSET)
     mouse_mode: MouseMode = .none,
     mouse_encoding: MouseEncoding = .x10,
+
+    // Text selection state
+    selection: ?Selection = null,
 
     // Backarrow key mode (DECSET ?67): true=BS(0x08), false=DEL(0x7F)
     decbkm: bool = false,

--- a/src/term.zig
+++ b/src/term.zig
@@ -66,6 +66,21 @@ pub fn translateCharset(cp: u21, cs: CharsetType) u21 {
 
 pub const SavedDecMode = struct { mode: u16 = 0, value: bool = false };
 
+pub const MouseMode = enum(u3) {
+    none = 0,
+    x10 = 1,       // ?9: press only, no modifiers
+    normal = 2,     // ?1000: press + release
+    button = 3,     // ?1002: press + release + drag motion
+    any = 4,        // ?1003: press + release + all motion
+};
+
+pub const MouseEncoding = enum(u2) {
+    x10 = 0,       // CSI M + 3 bytes (max 223 cols)
+    utf8 = 1,      // ?1005: UTF-8 coords
+    sgr = 2,       // ?1006: CSI < Pb;Px;Py M/m
+    urxvt = 3,     // ?1015: CSI Pb;Px;Py M
+};
+
 pub const Term = struct {
     const Self = @This();
 
@@ -121,7 +136,7 @@ pub const Term = struct {
     current_hyperlink_id: u16 = 0,
 
     // VT response buffer — accumulated responses flushed by event loop via ptyBufferedWrite
-    vt_response_buf: [4096]u8 = undefined,
+    vt_response_buf: [16384]u8 = undefined,
     vt_response_len: u16 = 0,
 
     // OSC 52 clipboard output
@@ -175,6 +190,10 @@ pub const Term = struct {
 
     // Focus event tracking (DECSET ?1004)
     focus_events: bool = false,
+
+    // Mouse tracking modes (DECSET)
+    mouse_mode: MouseMode = .none,
+    mouse_encoding: MouseEncoding = .x10,
 
     // Backarrow key mode (DECSET ?67): true=BS(0x08), false=DEL(0x7F)
     decbkm: bool = false,
@@ -712,7 +731,10 @@ pub const Term = struct {
     /// Queue a VT response to be flushed by the event loop (avoids direct write to non-blocking fd)
     pub fn queueResponse(self: *Self, data: []const u8) void {
         const avail = self.vt_response_buf.len - self.vt_response_len;
-        if (data.len > avail) return; // Drop entire response rather than partial write
+        if (data.len > avail) {
+            std.log.warn("VT response buffer full ({d}/{d}), dropping {d} bytes", .{ self.vt_response_len, self.vt_response_buf.len, data.len });
+            return;
+        }
         @memcpy(self.vt_response_buf[self.vt_response_len..][0..data.len], data);
         self.vt_response_len += @intCast(data.len);
     }

--- a/src/vt.zig
+++ b/src/vt.zig
@@ -387,6 +387,13 @@ pub const Parser = struct {
             return .none;
         }
 
+        // CAN/SUB abort — return to ground state per VT220 spec
+        if (byte == 0x18 or byte == 0x1A) {
+            self.state = .ground;
+            self.osc_len = 0;
+            return .none;
+        }
+
         if (byte == 0x07) {
             // BEL terminates OSC
             self.state = .ground;
@@ -399,6 +406,10 @@ pub const Parser = struct {
             if (self.osc_len < 8192) {
                 self.osc_buf[self.osc_len] = byte;
                 self.osc_len += 1;
+            } else {
+                // Buffer full — abort to prevent stuck state
+                self.state = .ground;
+                self.osc_len = 0;
             }
             return .none;
         }
@@ -425,6 +436,14 @@ pub const Parser = struct {
                 // Fall through to store the current byte
             }
         }
+
+        // CAN/SUB abort — return to ground state per VT220 spec
+        if (byte == 0x18 or byte == 0x1A) {
+            self.state = .ground;
+            self.osc_len = 0;
+            return .none;
+        }
+
         if (byte == 0x07) {
             // BEL terminates DCS (like OSC)
             const payload = self.osc_buf[0..self.osc_len];
@@ -440,6 +459,10 @@ pub const Parser = struct {
             if (self.osc_len < 8192) {
                 self.osc_buf[self.osc_len] = byte;
                 self.osc_len += 1;
+            } else {
+                // Buffer full — abort to prevent stuck state
+                self.state = .ground;
+                self.osc_len = 0;
             }
         }
         return .none;
@@ -1836,8 +1859,18 @@ fn handleDecSet(csi: CsiAction, term: *Term, set: bool) void {
             },
             2004 => term.bracketed_paste = set,
             2026 => term.sync_update = set,
-            // Mouse tracking modes (accepted but not processed — no mouse support yet)
-            9, 1000, 1001, 1002, 1003, 1005, 1006, 1015, 1016 => {},
+            9 => {
+                term.mouse_mode = if (set) .x10 else .none;
+                if (set) term.mouse_encoding = .x10;
+            },
+            1000 => term.mouse_mode = if (set) .normal else .none,
+            1001 => term.mouse_mode = if (set) .normal else .none, // highlight → treat as normal
+            1002 => term.mouse_mode = if (set) .button else .none,
+            1003 => term.mouse_mode = if (set) .any else .none,
+            1005 => term.mouse_encoding = if (set) .utf8 else .x10,
+            1006 => term.mouse_encoding = if (set) .sgr else .x10,
+            1015 => term.mouse_encoding = if (set) .urxvt else .x10,
+            1016 => term.mouse_encoding = if (set) .sgr else .x10, // SGR-pixel → treat as SGR
             1004 => term.focus_events = set, // Focus events (CSI I / CSI O)
             // Alt scroll mode
             1007 => {},


### PR DESCRIPTION
## **User description**
## Summary
- Fix input becoming unresponsive during long Claude Code sessions (heavy terminal output)
- Fix IME (fcitx5) permanently disabling after XIM timeout
- Fix X11 SHM backpressure causing gradual performance degradation

## Root Causes Found
1. **PTY write buffer shared between VT responses and keyboard input** — VT responses fill 64KB buffer, keystrokes silently dropped
2. **VT response buffer (4KB) overflow** — responses dropped, child process hangs waiting
3. **OSC/DCS parser stuck state** — no CAN/SUB abort, no overflow exit from osc_string
4. **4MB extra PTY drain monopolizes event loop** — starves input processing
5. **X11 SHM put_image with no backpressure** — xcb_flush() blocks when socket buffer full, event loop stalls progressively
6. **IME cursor update storm** — XIM requests sent every loop iteration during heavy output
7. **XIM disconnect with no reconnection** — 5s timeout permanently disables IME

## Changes

### main.zig
- Add proactive write buffer flush at loop start (input priority)
- Flush VT responses after each feedBulk chunk (prevents 4KB overflow)
- Reduce extra PTY drain cap from 4MB to 1MB
- Cap adaptive frame rate Tier 3 at 64ms (was 192ms)
- Move IME cursor update to render-only path

### term.zig
- Expand VT response buffer from 4KB to 16KB
- Add overflow warning log

### vt.zig
- Add CAN (0x18) / SUB (0x1A) abort for OSC and DCS states (VT220 spec)
- Auto-abort OSC/DCS on buffer full (prevents permanent parser stuck)

### x11.zig
- SHM completion backpressure: send_event=1, skip frame when busy
- 100ms shm_busy timeout fallback
- Query SHM extension first_event for completion detection
- XIM reconnection on timeout and disconnect

## Test plan
- [x] `zig build test` passes
- [x] Build with X11/fish/JP keymap succeeds
- [ ] Long Claude Code session — input stays responsive
- [ ] IME (fcitx5) stays functional after extended use
- [ ] Heavy output (`cat /dev/urandom | head -c 10M`) doesn't freeze input

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add mouse selection, clipboard copy, and full mouse event support in the terminal**

### What Changed
- The terminal now handles mouse clicks, drag selection, and wheel scrolling in supported apps.
- Dragging with the left mouse button highlights selected text; releasing copies the selected text to the clipboard.
- Selected text is cleared when new terminal output arrives, and Shift-click bypasses app mouse capture so text selection still works.
- The terminal now keeps input moving during heavy output, so keystrokes are less likely to lag or freeze.
- IME input recovers after timeouts instead of staying disabled, and mouse wheel events are passed through on Wayland and X11.

### Impact
`✅ Text selection in the terminal`
`✅ Clipboard copy from selected terminal text`
`✅ Fewer input freezes during long sessions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **マウスイベント対応** - マウスの移動、ボタン操作、ホイール入力をサポート
* **マウス選択機能** - Shift+ドラッグでテキスト選択が可能に
* **VTマウスモード対応** - X10、SGR、UTF-8、URXVTなど複数のマウスエンコーディング方式に対応

## バグ修正

* OSC/DCS文字列の適切なキャンセルハンドリングを追加
* VT応答バッファのオーバーフロー対策を強化
* レスポンシブネス向上のため、フレームレート制御を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->