### PR TITLE
feat(font): build-time custom font embedding (BDF + TTF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ zig build -Dbackend=x11 -Dscrollback_lines=0 -Doptimize=ReleaseFast
 # Smaller scrollback (lower memory)
 zig build -Dbackend=x11 -Dscrollback_lines=2000 -Doptimize=ReleaseFast
 
+# Custom BDF or TTF font (experimental — see Font section)
+zig build -Dbackend=x11 -Dfont=path/to/myfont.ttf -Doptimize=ReleaseFast
+
 # Cross-compile for aarch64
 zig build -Dtarget=aarch64-linux -Doptimize=ReleaseSmall
 
@@ -148,6 +151,43 @@ curl -Lo src/fonts/ufo-nf.bin https://github.com/midasdf/zt-fonts/raw/main/ufo-n
 
 See [zt-fonts](https://github.com/midasdf/zt-fonts) for sources, build scripts, and custom fonts.
 
+### Custom fonts (experimental)
+
+You can embed your own font instead of the default blob with `-Dfont`. Both
+bitmap (BDF) and TrueType outline (TTF) fonts are accepted:
+
+```sh
+# Bitmap font
+zig build -Dbackend=x11 -Dfont=path/to/myfont.bdf -Doptimize=ReleaseFast
+
+# TrueType outline font (rasterized to the 8x16 cell at build time)
+zig build -Dbackend=x11 -Dfont=path/to/myfont.ttf -Doptimize=ReleaseFast
+```
+
+Everything happens at build time via pure-Zig host tools, with **no external
+dependencies** (no FreeType, no FontForge):
+
+- `tools/ttf2bdf.zig` rasterizes TrueType (`glyf`) outlines into a fixed-cell,
+  1-bit BDF — scaling is derived from the font's own metrics (advance width →
+  cell width, ascent/descent → cell height).
+- `tools/bdf2blob.zig` packs the BDF into zt's binary blob format.
+
+The runtime stays zero-dependency: only the resulting blob is embedded, exactly
+as with the default font.
+
+Example — [Topaz NG](https://codeberg.org/ideasman42/font-topaz-ng), a vector
+revival of the Amiga Topaz font (its 8×16 cell matches zt natively):
+
+```sh
+zig build -Dbackend=x11 -Dfont=TopazNG_Code-Regular.ttf -Doptimize=ReleaseFast
+```
+
+> **Experimental.** Glyphs are embedded as 1-bit monochrome bitmaps at the fixed
+> 8×16 cell (no antialiasing, no color emoji). TrueType `glyf` outlines only —
+> CFF-based **OTF is not supported** (use the `.ttf` variant). Fine-tuning flags
+> are available when running `tools/ttf2bdf.zig` directly (`--baseline`,
+> `--xscale`, `--yscale`, `--xoff`, `--preview`).
+
 ## Architecture
 
 ```
@@ -173,7 +213,7 @@ Some applications may have minor rendering issues due to missing features (see b
 - **Mouse wheel** — scrolls scrollback in main screen; translates to arrow keys for `less`/`vim` in alt screen; passes through to apps with mouse capture (`mouse_mode != .none`).
 - **No clipboard paste on fbdev** — X11/Wayland support Ctrl+Shift+V
 - **No inline pre-edit display** — IME uses its own popup window
-- **No font fallback** — single embedded font, no system font lookup
+- **Bitmap rendering only** — single embedded blob (1-bit, fixed 8×16 cell), no antialiasing, no runtime system font lookup or fallback. A custom BDF or TTF can be embedded at build time via `-Dfont` (experimental, see [Font](#custom-fonts-experimental))
 - **No ligatures**
 - **No sixel/image protocol**
 - **Blink attribute** — parsed but not visually rendered

--- a/build.zig
+++ b/build.zig
@@ -35,11 +35,11 @@ pub fn build(b: *std.Build) void {
     // The font is converted to zt's binary blob format at build time by the
     // pure-Zig host tools (no external dependencies):
     //   - .bdf       -> tools/bdf2blob.zig
-    //   - .ttf/.ttc  -> tools/ttf2bdf.zig (rasterize outlines) -> bdf2blob
+    //   - .ttf       -> tools/ttf2bdf.zig (rasterize outlines) -> bdf2blob
     // Without -Dfont, the committed src/fonts/ufo-nf.bin is used.
     const font_opt = b.option([]const u8, "font", "Path to a custom BDF or TTF font to embed instead of the default (EXPERIMENTAL)");
     const font_blob: std.Build.LazyPath = if (font_opt) |font_path| blk: {
-        const is_ttf = std.mem.endsWith(u8, font_path, ".ttf") or std.mem.endsWith(u8, font_path, ".ttc");
+        const is_ttf = std.mem.endsWith(u8, font_path, ".ttf");
         if (!is_ttf and !std.mem.endsWith(u8, font_path, ".bdf")) {
             std.debug.panic("-Dfont: unsupported font '{s}'; expected .bdf or .ttf (OTF/CFF is not supported)", .{font_path});
         }

--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,36 @@ pub fn build(b: *std.Build) void {
         std.debug.panic("invalid -Dkeymap='{s}'; expected us or jp", .{keymap_opt});
     }
 
+    // EXPERIMENTAL: embed a custom font instead of the default blob.
+    // The font is converted to zt's binary blob format at build time by the
+    // pure-Zig host tools (no external dependencies):
+    //   - .bdf       -> tools/bdf2blob.zig
+    //   - .ttf/.ttc  -> tools/ttf2bdf.zig (rasterize outlines) -> bdf2blob
+    // Without -Dfont, the committed src/fonts/ufo-nf.bin is used.
+    const font_opt = b.option([]const u8, "font", "Path to a custom BDF or TTF font to embed instead of the default (EXPERIMENTAL)");
+    const font_blob: std.Build.LazyPath = if (font_opt) |font_path| blk: {
+        const is_ttf = std.mem.endsWith(u8, font_path, ".ttf") or std.mem.endsWith(u8, font_path, ".ttc");
+        if (!is_ttf and !std.mem.endsWith(u8, font_path, ".bdf")) {
+            std.debug.panic("-Dfont: unsupported font '{s}'; expected .bdf or .ttf (OTF/CFF is not supported)", .{font_path});
+        }
+
+        // .ttf -> intermediate .bdf via the rasterizer.
+        const bdf_path: std.Build.LazyPath = if (is_ttf) tt: {
+            const ttf2bdf = hostTool(b, "ttf2bdf");
+            const run = b.addRunArtifact(ttf2bdf);
+            run.stdio = .inherit;
+            run.addFileArg(.{ .cwd_relative = font_path });
+            break :tt run.addOutputFileArg("font.bdf");
+        } else .{ .cwd_relative = font_path };
+
+        // .bdf -> binary blob.
+        const bdf2blob = hostTool(b, "bdf2blob");
+        const run = b.addRunArtifact(bdf2blob);
+        run.stdio = .inherit;
+        run.addFileArg(bdf_path);
+        break :blk run.addOutputFileArg("ufo-nf.bin");
+    } else b.path("src/fonts/ufo-nf.bin");
+
     const scale_opt = b.option(u32, "scale", "Pixel scale factor: 1, 2, or 4 (default: 1)") orelse 1;
     const max_fps_opt = b.option(u32, "max_fps", "Maximum frame rate: 0 = unlimited (default: 120)") orelse 120;
     const pty_buf_kb_opt = b.option(u32, "pty_buf_kb", "PTY read buffer size in KB (default: 1024)") orelse 1024;
@@ -51,7 +81,7 @@ pub fn build(b: *std.Build) void {
     options.addOption(u32, "pty_buf_kb", pty_buf_kb_opt);
     options.addOption(u32, "scrollback_lines", scrollback_lines_opt);
     options.addOption([:0]const u8, "shell", shell_opt);
-    options.addOption([:0]const u8, "version", b.allocator.dupeZ(u8, "0.8.0") catch @panic("OOM"));
+    options.addOption([:0]const u8, "version", b.allocator.dupeZ(u8, "0.9.0") catch @panic("OOM"));
 
     const config_mod = b.createModule(.{
         .root_source_file = b.path("config.zig"),
@@ -71,6 +101,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "config", .module = config_mod },
         },
     });
+    exe_mod.addAnonymousImport("font_blob", .{ .root_source_file = font_blob });
 
     const exe = b.addExecutable(.{
         .name = "zt",
@@ -151,6 +182,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "config", .module = config_mod },
         },
     });
+    test_mod.addAnonymousImport("font_blob", .{ .root_source_file = font_blob });
 
     const unit_tests = b.addTest(.{
         .root_module = test_mod,
@@ -209,4 +241,16 @@ pub fn build(b: *std.Build) void {
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
+}
+
+/// Build a pure-Zig font-conversion tool for the host (used at build time).
+fn hostTool(b: *std.Build, name: []const u8) *std.Build.Step.Compile {
+    return b.addExecutable(.{
+        .name = name,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path(b.fmt("tools/{s}.zig", .{name})),
+            .target = b.graph.host,
+            .optimize = .ReleaseFast,
+        }),
+    });
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zt,
-    .version = "0.7.1",
+    .version = "0.9.0",
     .minimum_zig_version = "0.16.0",
     .fingerprint = 0xc36136a6af00f24b,
     .paths = .{
@@ -9,5 +9,6 @@
         "src",
         "config.zig",
         "fonts",
+        "tools",
     },
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,9 +46,12 @@ const EncodedMouse = struct {
     }
 };
 
-// Embed font at comptime
-// Large fonts use pre-compiled blob (bdf2blob.py) to avoid slow comptime parsing
-const FontType = font_mod.FontBlob(@embedFile("fonts/ufo-nf.bin"));
+// Embed font at comptime.
+// Large fonts use a pre-compiled blob (tools/bdf2blob.zig) to avoid slow
+// comptime BDF parsing. The "font_blob" import is wired up in build.zig: it is
+// the committed src/fonts/ufo-nf.bin by default, or a blob generated at build
+// time from a custom BDF passed via -Dfont (EXPERIMENTAL).
+const FontType = font_mod.FontBlob(@embedFile("font_blob"));
 
 // =============================================================================
 // Signal handling via signalfd

--- a/tools/bdf2blob.zig
+++ b/tools/bdf2blob.zig
@@ -1,0 +1,162 @@
+//! Convert a BDF font to a binary blob for zt's font module.
+//!
+//! Usage: bdf2blob <input.bdf> <output.bin>
+//!
+//! Binary format:
+//!   Header:
+//!     u32 LE: glyph_count
+//!     u32 LE: bitmap_data_total_bytes
+//!   Glyph table (glyph_count entries, sorted by codepoint):
+//!     u32 LE: codepoint
+//!     u16 LE: width
+//!     u16 LE: height
+//!     u32 LE: bitmap_offset (into bitmap data)
+//!     u16 LE: bitmap_len (bytes)
+//!     u16 LE: padding (0)
+//!   Bitmap data:
+//!     Raw bitmap bytes (1 bit per pixel, row-major, packed)
+
+const std = @import("std");
+const Io = std.Io;
+
+const Glyph = struct {
+    codepoint: u32,
+    width: u16,
+    height: u16,
+    bitmap: []const u8,
+};
+
+fn glyphLessThan(_: void, a: Glyph, b: Glyph) bool {
+    return a.codepoint < b.codepoint;
+}
+
+fn hexVal(c: u8) ?u8 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'a'...'f' => c - 'a' + 10,
+        'A'...'F' => c - 'A' + 10,
+        else => null,
+    };
+}
+
+/// Decode a BDF hex row (e.g. "FF", "C3 80") into packed bytes.
+/// Non-hex characters (whitespace) are ignored, matching Python's bytes.fromhex.
+fn appendHexBytes(out: *std.ArrayList(u8), gpa: std.mem.Allocator, row: []const u8) !void {
+    var hi: ?u8 = null;
+    for (row) |c| {
+        const v = hexVal(c) orelse continue;
+        if (hi) |h| {
+            try out.append(gpa, (h << 4) | v);
+            hi = null;
+        } else {
+            hi = v;
+        }
+    }
+}
+
+fn putU16(out: *std.ArrayList(u8), gpa: std.mem.Allocator, v: u16) !void {
+    var b: [2]u8 = undefined;
+    std.mem.writeInt(u16, &b, v, .little);
+    try out.appendSlice(gpa, &b);
+}
+
+fn putU32(out: *std.ArrayList(u8), gpa: std.mem.Allocator, v: u32) !void {
+    var b: [4]u8 = undefined;
+    std.mem.writeInt(u32, &b, v, .little);
+    try out.appendSlice(gpa, &b);
+}
+
+pub fn main(init: std.process.Init) !void {
+    const a = init.arena.allocator();
+    const io = init.io;
+
+    var ait = try std.process.Args.Iterator.initAllocator(init.minimal.args, a);
+    defer ait.deinit();
+    const prog = ait.next() orelse "bdf2blob";
+    const input_path = ait.next();
+    const output_path = ait.next();
+    if (input_path == null or output_path == null or ait.next() != null) {
+        std.debug.print("Usage: {s} <input.bdf> <output.bin>\n", .{prog});
+        std.process.exit(1);
+    }
+
+    const cwd = Io.Dir.cwd();
+    const data = try cwd.readFileAlloc(io, input_path.?, a, .unlimited);
+
+    var glyphs: std.ArrayList(Glyph) = .empty;
+
+    var in_bitmap = false;
+    var codepoint: i64 = -1;
+    var width: u16 = 0;
+    var height: u16 = 0;
+    var rows: std.ArrayList([]const u8) = .empty;
+
+    var it = std.mem.splitScalar(u8, data, '\n');
+    while (it.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (std.mem.startsWith(u8, line, "STARTCHAR")) {
+            in_bitmap = false;
+            codepoint = -1;
+            width = 0;
+            height = 0;
+            rows.clearRetainingCapacity();
+        } else if (std.mem.startsWith(u8, line, "ENCODING")) {
+            var t = std.mem.tokenizeScalar(u8, line, ' ');
+            _ = t.next(); // "ENCODING"
+            if (t.next()) |tok| codepoint = std.fmt.parseInt(i64, tok, 10) catch -1;
+        } else if (std.mem.startsWith(u8, line, "BBX")) {
+            var t = std.mem.tokenizeScalar(u8, line, ' ');
+            _ = t.next(); // "BBX"
+            const w = t.next() orelse continue;
+            const h = t.next() orelse continue;
+            width = @intCast(std.fmt.parseInt(i64, w, 10) catch 0);
+            height = @intCast(std.fmt.parseInt(i64, h, 10) catch 0);
+        } else if (std.mem.eql(u8, line, "BITMAP")) {
+            in_bitmap = true;
+        } else if (std.mem.eql(u8, line, "ENDCHAR")) {
+            if (in_bitmap and codepoint >= 0) {
+                var bytes: std.ArrayList(u8) = .empty;
+                for (rows.items) |row| try appendHexBytes(&bytes, a, row);
+                try glyphs.append(a, .{
+                    .codepoint = @intCast(codepoint),
+                    .width = width,
+                    .height = height,
+                    .bitmap = bytes.items,
+                });
+            }
+            in_bitmap = false;
+        } else if (in_bitmap) {
+            try rows.append(a, line); // slice into `data`, stable for program lifetime
+        }
+    }
+
+    std.sort.pdq(Glyph, glyphs.items, {}, glyphLessThan);
+
+    const glyph_count: u32 = @intCast(glyphs.items.len);
+    var bitmap_total: u32 = 0;
+    for (glyphs.items) |g| bitmap_total += @intCast(g.bitmap.len);
+
+    var out: std.ArrayList(u8) = .empty;
+    // Header
+    try putU32(&out, a, glyph_count);
+    try putU32(&out, a, bitmap_total);
+    // Glyph table
+    var offset: u32 = 0;
+    for (glyphs.items) |g| {
+        try putU32(&out, a, g.codepoint);
+        try putU16(&out, a, g.width);
+        try putU16(&out, a, g.height);
+        try putU32(&out, a, offset);
+        try putU16(&out, a, @intCast(g.bitmap.len));
+        try putU16(&out, a, 0); // padding
+        offset += @intCast(g.bitmap.len);
+    }
+    // Bitmap data
+    for (glyphs.items) |g| try out.appendSlice(a, g.bitmap);
+
+    try cwd.writeFile(io, .{ .sub_path = output_path.?, .data = out.items });
+
+    std.debug.print("Written {d} glyphs, {d} bitmap bytes\n", .{ glyph_count, bitmap_total });
+    std.debug.print("Glyph table: {d} bytes\n", .{glyph_count * 16});
+    std.debug.print("Total blob: {d} bytes\n", .{8 + glyph_count * 16 + bitmap_total});
+}

--- a/tools/bdf2blob.zig
+++ b/tools/bdf2blob.zig
@@ -52,6 +52,7 @@ fn appendHexBytes(out: *std.ArrayList(u8), gpa: std.mem.Allocator, row: []const 
             hi = v;
         }
     }
+    if (hi != null) return error.InvalidHexRow;
 }
 
 fn putU16(out: *std.ArrayList(u8), gpa: std.mem.Allocator, v: u16) !void {

--- a/tools/ttf2bdf.zig
+++ b/tools/ttf2bdf.zig
@@ -1,0 +1,532 @@
+//! Rasterize a TrueType (`glyf`-outline) font into a fixed-cell, 1-bit BDF
+//! bitmap font for zt. Pure Zig, no external dependencies.
+//!
+//! Usage: ttf2bdf <input.ttf> <output.bdf> [--ppem N] [--baseline B]
+//!                [--xoff X] [--preview]
+//!
+//! Each glyph is rendered into a CELL_W x CELL_H monochrome cell, baseline-
+//! aligned, MSB-first packed rows (matching zt's renderer and bdf2blob). Only
+//! TrueType outlines (`glyf` + `loca`) are supported; CFF/OTF is not.
+
+const std = @import("std");
+
+const CELL_W: u32 = 8;
+const CELL_H: u32 = 16;
+const BEZIER_STEPS: u32 = 8;
+
+const Pt = struct { x: f64, y: f64, on: bool };
+const Edge = struct { x0: f64, y0: f64, x1: f64, y1: f64 };
+const Xform = struct {
+    a: f64 = 1,
+    b: f64 = 0,
+    c: f64 = 0,
+    d: f64 = 1,
+    e: f64 = 0,
+    f: f64 = 0,
+    fn apply(t: Xform, x: f64, y: f64) [2]f64 {
+        return .{ t.a * x + t.c * y + t.e, t.b * x + t.d * y + t.f };
+    }
+    fn compose(p: Xform, q: Xform) Xform {
+        // result = p ∘ q  (apply q, then p)
+        return .{
+            .a = p.a * q.a + p.c * q.b,
+            .b = p.b * q.a + p.d * q.b,
+            .c = p.a * q.c + p.c * q.d,
+            .d = p.b * q.c + p.d * q.d,
+            .e = p.a * q.e + p.c * q.f + p.e,
+            .f = p.b * q.e + p.d * q.f + p.f,
+        };
+    }
+};
+
+fn rdU16(d: []const u8, o: usize) u16 {
+    return std.mem.readInt(u16, d[o..][0..2], .big);
+}
+fn rdI16(d: []const u8, o: usize) i16 {
+    return std.mem.readInt(i16, d[o..][0..2], .big);
+}
+fn rdU32(d: []const u8, o: usize) u32 {
+    return std.mem.readInt(u32, d[o..][0..4], .big);
+}
+
+const XCross = struct { x: f64, dir: i32 };
+
+const Font = struct {
+    data: []const u8,
+    units_per_em: f64,
+    num_glyphs: u16,
+    loc_long: bool,
+    off_loca: usize,
+    off_glyf: usize,
+    off_cmap: usize,
+
+    fn locaAt(self: Font, gid: u32) usize {
+        if (self.loc_long) {
+            return rdU32(self.data, self.off_loca + gid * 4);
+        } else {
+            return @as(usize, rdU16(self.data, self.off_loca + gid * 2)) * 2;
+        }
+    }
+};
+
+fn findTable(d: []const u8, tag: *const [4]u8) ?usize {
+    const num = rdU16(d, 4);
+    var i: usize = 0;
+    while (i < num) : (i += 1) {
+        const rec = 12 + i * 16;
+        if (std.mem.eql(u8, d[rec..][0..4], tag)) return rdU32(d, rec + 8);
+    }
+    return null;
+}
+
+/// Append the glyph's contours (in font units) to `contours`, applying `xf`.
+fn collectGlyph(
+    font: Font,
+    gid: u32,
+    xf: Xform,
+    depth: u32,
+    a: std.mem.Allocator,
+    contours: *std.ArrayList([]Pt),
+) !void {
+    if (depth > 8) return;
+    const start = font.locaAt(gid);
+    const end = font.locaAt(gid + 1);
+    if (end <= start) return; // empty glyph (e.g. space)
+    const d = font.data;
+    var o = font.off_glyf + start;
+    const num_contours = rdI16(d, o);
+    o += 10; // skip numberOfContours + bbox
+
+    if (num_contours >= 0) {
+        const nc: usize = @intCast(num_contours);
+        var end_pts = try a.alloc(u16, nc);
+        defer a.free(end_pts);
+        for (0..nc) |i| {
+            end_pts[i] = rdU16(d, o);
+            o += 2;
+        }
+        const num_points: usize = if (nc == 0) 0 else @as(usize, end_pts[nc - 1]) + 1;
+        const instr_len = rdU16(d, o);
+        o += 2 + instr_len;
+
+        // Flags (with repeat compression).
+        var flags = try a.alloc(u8, num_points);
+        defer a.free(flags);
+        var i: usize = 0;
+        while (i < num_points) {
+            const fl = d[o];
+            o += 1;
+            flags[i] = fl;
+            i += 1;
+            if (fl & 0x08 != 0) {
+                var rep = d[o];
+                o += 1;
+                while (rep > 0 and i < num_points) : (rep -= 1) {
+                    flags[i] = fl;
+                    i += 1;
+                }
+            }
+        }
+
+        // X coordinates.
+        var xs = try a.alloc(f64, num_points);
+        defer a.free(xs);
+        var xv: i32 = 0;
+        for (0..num_points) |k| {
+            const fl = flags[k];
+            if (fl & 0x02 != 0) {
+                const dx: i32 = d[o];
+                o += 1;
+                xv += if (fl & 0x10 != 0) dx else -dx;
+            } else if (fl & 0x10 == 0) {
+                xv += @as(i32, rdI16(d, o));
+                o += 2;
+            }
+            xs[k] = @floatFromInt(xv);
+        }
+        // Y coordinates.
+        var ys = try a.alloc(f64, num_points);
+        defer a.free(ys);
+        var yv: i32 = 0;
+        for (0..num_points) |k| {
+            const fl = flags[k];
+            if (fl & 0x04 != 0) {
+                const dy: i32 = d[o];
+                o += 1;
+                yv += if (fl & 0x20 != 0) dy else -dy;
+            } else if (fl & 0x20 == 0) {
+                yv += @as(i32, rdI16(d, o));
+                o += 2;
+            }
+            ys[k] = @floatFromInt(yv);
+        }
+
+        // Split into contours, applying the transform.
+        var s: usize = 0;
+        for (0..nc) |ci| {
+            const e: usize = end_pts[ci];
+            const len = e - s + 1;
+            var pts = try a.alloc(Pt, len);
+            for (0..len) |j| {
+                const p = xf.apply(xs[s + j], ys[s + j]);
+                pts[j] = .{ .x = p[0], .y = p[1], .on = (flags[s + j] & 0x01) != 0 };
+            }
+            try contours.append(a, pts);
+            s = e + 1;
+        }
+    } else {
+        // Composite glyph.
+        while (true) {
+            const comp_flags = rdU16(d, o);
+            const comp_gid = rdU16(d, o + 2);
+            o += 4;
+            var arg1: i32 = undefined;
+            var arg2: i32 = undefined;
+            if (comp_flags & 0x0001 != 0) { // ARG_1_AND_2_ARE_WORDS
+                arg1 = rdI16(d, o);
+                arg2 = rdI16(d, o + 2);
+                o += 4;
+            } else {
+                arg1 = @as(i8, @bitCast(d[o]));
+                arg2 = @as(i8, @bitCast(d[o + 1]));
+                o += 2;
+            }
+            var cxf = Xform{};
+            if (comp_flags & 0x0008 != 0) { // WE_HAVE_A_SCALE
+                const sc = f2dot14(rdI16(d, o));
+                o += 2;
+                cxf.a = sc;
+                cxf.d = sc;
+            } else if (comp_flags & 0x0040 != 0) { // X_AND_Y_SCALE
+                cxf.a = f2dot14(rdI16(d, o));
+                cxf.d = f2dot14(rdI16(d, o + 2));
+                o += 4;
+            } else if (comp_flags & 0x0080 != 0) { // TWO_BY_TWO
+                cxf.a = f2dot14(rdI16(d, o));
+                cxf.b = f2dot14(rdI16(d, o + 2));
+                cxf.c = f2dot14(rdI16(d, o + 4));
+                cxf.d = f2dot14(rdI16(d, o + 6));
+                o += 8;
+            }
+            if (comp_flags & 0x0002 != 0) { // ARGS_ARE_XY_VALUES
+                cxf.e = @floatFromInt(arg1);
+                cxf.f = @floatFromInt(arg2);
+            }
+            try collectGlyph(font, comp_gid, xf.compose(cxf), depth + 1, a, contours);
+            if (comp_flags & 0x0020 == 0) break; // no MORE_COMPONENTS
+        }
+    }
+}
+
+fn f2dot14(v: i16) f64 {
+    return @as(f64, @floatFromInt(v)) / 16384.0;
+}
+
+/// Flatten one contour into edges (in pixel space already), via the supplied
+/// unit->pixel mapping closure parameters.
+fn flattenContour(pts: []const Pt, a: std.mem.Allocator, edges: *std.ArrayList(Edge)) !void {
+    if (pts.len < 2) return;
+
+    // Build an on-curve-normalized point list: insert implicit midpoints
+    // between consecutive off-curve points.
+    var exp: std.ArrayList(Pt) = .empty;
+    defer exp.deinit(a);
+    for (pts, 0..) |p, k| {
+        try exp.append(a, p);
+        const nxt = pts[(k + 1) % pts.len];
+        if (!p.on and !nxt.on) {
+            try exp.append(a, .{ .x = (p.x + nxt.x) / 2, .y = (p.y + nxt.y) / 2, .on = true });
+        }
+    }
+    // Rotate so the first point is on-curve.
+    var first_on: ?usize = null;
+    for (exp.items, 0..) |p, k| {
+        if (p.on) {
+            first_on = k;
+            break;
+        }
+    }
+    if (first_on == null) return; // all off-curve: degenerate, skip
+    const rot = first_on.?;
+
+    const n = exp.items.len;
+    var seq = try a.alloc(Pt, n + 1);
+    defer a.free(seq);
+    for (0..n) |k| seq[k] = exp.items[(rot + k) % n];
+    seq[n] = seq[0]; // close
+
+    var cur = seq[0];
+    var idx: usize = 1;
+    while (idx < seq.len) {
+        const p = seq[idx];
+        if (p.on) {
+            try edges.append(a, .{ .x0 = cur.x, .y0 = cur.y, .x1 = p.x, .y1 = p.y });
+            cur = p;
+            idx += 1;
+        } else {
+            const ctrl = p;
+            const e = seq[idx + 1]; // guaranteed on-curve
+            var t: u32 = 1;
+            var prev = cur;
+            while (t <= BEZIER_STEPS) : (t += 1) {
+                const u = @as(f64, @floatFromInt(t)) / @as(f64, @floatFromInt(BEZIER_STEPS));
+                const mu = 1.0 - u;
+                const qx = mu * mu * cur.x + 2 * mu * u * ctrl.x + u * u * e.x;
+                const qy = mu * mu * cur.y + 2 * mu * u * ctrl.y + u * u * e.y;
+                try edges.append(a, .{ .x0 = prev.x, .y0 = prev.y, .x1 = qx, .y1 = qy });
+                prev = .{ .x = qx, .y = qy, .on = true };
+            }
+            cur = e;
+            idx += 2;
+        }
+    }
+}
+
+/// Nonzero-winding scanline fill into a CELL_W x CELL_H 1-bit cell.
+/// Returns 16 bytes (one per row, MSB = leftmost pixel).
+fn rasterize(edges: []const Edge, a: std.mem.Allocator) ![CELL_H]u8 {
+    var cell = [_]u8{0} ** CELL_H;
+    var xs: std.ArrayList(XCross) = .empty;
+    defer xs.deinit(a);
+
+    var row: u32 = 0;
+    while (row < CELL_H) : (row += 1) {
+        const yc = @as(f64, @floatFromInt(row)) + 0.5;
+        xs.clearRetainingCapacity();
+        for (edges) |e| {
+            const y0 = e.y0;
+            const y1 = e.y1;
+            if (y0 == y1) continue;
+            const lo = @min(y0, y1);
+            const hi = @max(y0, y1);
+            if (yc < lo or yc >= hi) continue;
+            const t = (yc - y0) / (y1 - y0);
+            const x = e.x0 + t * (e.x1 - e.x0);
+            try xs.append(a, .{ .x = x, .dir = if (y1 > y0) 1 else -1 });
+        }
+        if (xs.items.len < 2) continue;
+        std.sort.pdq(XCross, xs.items, {}, struct {
+            fn lt(_: void, p: XCross, q: XCross) bool {
+                return p.x < q.x;
+            }
+        }.lt);
+
+        var wind: i32 = 0;
+        var i: usize = 0;
+        while (i + 1 < xs.items.len) : (i += 1) {
+            wind += xs.items[i].dir;
+            if (wind == 0) continue;
+            const xa = xs.items[i].x;
+            const xb = xs.items[i + 1].x;
+            var col: u32 = 0;
+            while (col < CELL_W) : (col += 1) {
+                const xc = @as(f64, @floatFromInt(col)) + 0.5;
+                if (xc >= xa and xc < xb) {
+                    cell[row] |= @as(u8, 0x80) >> @intCast(col);
+                }
+            }
+        }
+    }
+    return cell;
+}
+
+const Opts = struct {
+    // Optional overrides; when null they are derived from font metrics.
+    xscale: ?f64 = null,
+    yscale: ?f64 = null,
+    baseline: ?f64 = null,
+    xoff: f64 = 0.0,
+    preview: bool = false,
+};
+
+pub fn main(init: std.process.Init) !void {
+    const a = init.arena.allocator();
+    const io = init.io;
+
+    var ait = try std.process.Args.Iterator.initAllocator(init.minimal.args, a);
+    defer ait.deinit();
+    const prog = ait.next() orelse "ttf2bdf";
+    const input_path = ait.next();
+    const output_path = ait.next();
+    if (input_path == null or output_path == null) {
+        std.debug.print("Usage: {s} <input.ttf> <output.bdf> [--ppem N] [--baseline B] [--xoff X] [--preview]\n", .{prog});
+        std.process.exit(1);
+    }
+    var opts = Opts{};
+    while (ait.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--preview")) {
+            opts.preview = true;
+        } else if (std.mem.eql(u8, arg, "--xscale")) {
+            opts.xscale = std.fmt.parseFloat(f64, ait.next() orelse "0") catch null;
+        } else if (std.mem.eql(u8, arg, "--yscale")) {
+            opts.yscale = std.fmt.parseFloat(f64, ait.next() orelse "0") catch null;
+        } else if (std.mem.eql(u8, arg, "--baseline")) {
+            opts.baseline = std.fmt.parseFloat(f64, ait.next() orelse "0") catch null;
+        } else if (std.mem.eql(u8, arg, "--xoff")) {
+            opts.xoff = std.fmt.parseFloat(f64, ait.next() orelse "0") catch 0;
+        }
+    }
+
+    const cwd = std.Io.Dir.cwd();
+    const data = try cwd.readFileAlloc(io, input_path.?, a, .unlimited);
+
+    if (rdU32(data, 0) != 0x00010000 and !std.mem.eql(u8, data[0..4], "true")) {
+        std.debug.print("error: not a TrueType (glyf) font; CFF/OTF is unsupported\n", .{});
+        std.process.exit(1);
+    }
+
+    const off_head = findTable(data, "head") orelse fatal("missing head");
+    const off_maxp = findTable(data, "maxp") orelse fatal("missing maxp");
+    const off_hhea = findTable(data, "hhea") orelse fatal("missing hhea");
+    const off_hmtx = findTable(data, "hmtx") orelse fatal("missing hmtx");
+    const off_loca = findTable(data, "loca") orelse fatal("missing loca (CFF font?)");
+    const off_glyf = findTable(data, "glyf") orelse fatal("missing glyf (CFF font?)");
+    const off_cmap = findTable(data, "cmap") orelse fatal("missing cmap");
+
+    const font = Font{
+        .data = data,
+        .units_per_em = @floatFromInt(rdU16(data, off_head + 18)),
+        .num_glyphs = rdU16(data, off_maxp + 4),
+        .loc_long = rdI16(data, off_head + 50) != 0,
+        .off_loca = off_loca,
+        .off_glyf = off_glyf,
+        .off_cmap = off_cmap,
+    };
+
+    // Derive the unit->pixel mapping from font metrics so the cell is filled:
+    //  - horizontal: advance width -> CELL_W
+    //  - vertical:   ascent..descent span -> CELL_H, baseline at ascent
+    const advance: f64 = @floatFromInt(rdU16(data, off_hmtx)); // advanceWidth[0]
+    const ascent: f64 = @floatFromInt(rdI16(data, off_hhea + 4));
+    const descent: f64 = @floatFromInt(rdI16(data, off_hhea + 6)); // negative
+    const scale_x = opts.xscale orelse (@as(f64, @floatFromInt(CELL_W)) / advance);
+    const scale_y = opts.yscale orelse (@as(f64, @floatFromInt(CELL_H)) / (ascent - descent));
+    const baseline = opts.baseline orelse (ascent * scale_y);
+    const ydescent_rows = @as(i32, @intCast(CELL_H)) - @as(i32, @intFromFloat(@round(baseline)));
+
+    // Build codepoint -> glyph id from a Unicode cmap format-4 subtable.
+    var map = std.AutoHashMap(u21, u16).init(a);
+    try parseCmap4(data, off_cmap, &map);
+
+    var out: std.ArrayList(u8) = .empty;
+    try out.print(a,
+        \\STARTFONT 2.1
+        \\FONT -zt-TopazNG-Medium-R-Normal--16-160-75-75-C-80-ISO10646-1
+        \\SIZE 16 75 75
+        \\FONTBOUNDINGBOX {d} {d} 0 {d}
+        \\CHARS {d}
+        \\
+    , .{ CELL_W, CELL_H, -ydescent_rows, map.count() });
+
+    var edges: std.ArrayList(Edge) = .empty;
+    var contours: std.ArrayList([]Pt) = .empty;
+
+    var rendered: u32 = 0;
+    var it = map.iterator();
+    while (it.next()) |entry| {
+        const cp = entry.key_ptr.*;
+        const gid = entry.value_ptr.*;
+
+        contours.clearRetainingCapacity();
+        // Unit -> pixel transform baked into the collected contour points.
+        const xf = Xform{
+            .a = scale_x,
+            .d = -scale_y,
+            .e = opts.xoff,
+            .f = baseline,
+        };
+        try collectGlyph(font, gid, xf, 0, a, &contours);
+
+        edges.clearRetainingCapacity();
+        for (contours.items) |c| try flattenContour(c, a, &edges);
+        const cell = try rasterize(edges.items, a);
+
+        try out.print(a,
+            \\STARTCHAR U+{X:0>4}
+            \\ENCODING {d}
+            \\SWIDTH 500 0
+            \\DWIDTH {d} 0
+            \\BBX {d} {d} 0 {d}
+            \\BITMAP
+            \\
+        , .{ cp, cp, CELL_W, CELL_W, CELL_H, -ydescent_rows });
+        for (cell) |byte| try out.print(a, "{X:0>2}\n", .{byte});
+        try out.appendSlice(a, "ENDCHAR\n");
+        rendered += 1;
+
+        if (opts.preview and isPreviewCp(cp)) previewCell(cp, cell);
+    }
+    try out.appendSlice(a, "ENDFONT\n");
+
+    try cwd.writeFile(io, .{ .sub_path = output_path.?, .data = out.items });
+    std.debug.print("Rendered {d} glyphs at {d}x{d} (scale_x={d:.5}, scale_y={d:.5}, baseline={d:.2})\n", .{ rendered, CELL_W, CELL_H, scale_x, scale_y, baseline });
+}
+
+fn fatal(comptime msg: []const u8) noreturn {
+    std.debug.print("error: {s}\n", .{msg});
+    std.process.exit(1);
+}
+
+fn parseCmap4(d: []const u8, off_cmap: usize, map: *std.AutoHashMap(u21, u16)) !void {
+    const ntab = rdU16(d, off_cmap + 2);
+    var best: ?usize = null;
+    var i: usize = 0;
+    while (i < ntab) : (i += 1) {
+        const rec = off_cmap + 4 + i * 8;
+        const pid = rdU16(d, rec);
+        const eid = rdU16(d, rec + 2);
+        const so = rdU32(d, rec + 4);
+        const fmt = rdU16(d, off_cmap + so);
+        const unicode = (pid == 3 and (eid == 1 or eid == 10)) or pid == 0;
+        if (fmt == 4 and unicode) {
+            best = off_cmap + so;
+            if (pid == 3 and eid == 1) break; // prefer Windows BMP
+        }
+    }
+    const sub = best orelse fatal("no Unicode cmap format-4 subtable");
+    const seg_x2 = rdU16(d, sub + 6);
+    const segs = seg_x2 / 2;
+    const end_o = sub + 14;
+    const start_o = end_o + seg_x2 + 2;
+    const delta_o = start_o + seg_x2;
+    const range_o = delta_o + seg_x2;
+    for (0..segs) |s| {
+        const end_c = rdU16(d, end_o + s * 2);
+        const start_c = rdU16(d, start_o + s * 2);
+        const delta = rdU16(d, delta_o + s * 2);
+        const range = rdU16(d, range_o + s * 2);
+        if (start_c == 0xFFFF) continue;
+        var c: u32 = start_c;
+        while (c <= end_c) : (c += 1) {
+            var gid: u16 = 0;
+            const cc: u16 = @truncate(c);
+            if (range == 0) {
+                gid = cc +% delta;
+            } else {
+                const gi_off = range_o + s * 2 + range + (c - start_c) * 2;
+                const g = rdU16(d, gi_off);
+                if (g != 0) gid = g +% delta;
+            }
+            if (gid != 0) try map.put(@intCast(c), gid);
+        }
+    }
+}
+
+fn isPreviewCp(cp: u21) bool {
+    return switch (cp) {
+        'A', 'a', 'g', 'M', 'x', '0', '@', 0x2502, 0x2588, 0x250C => true,
+        else => false,
+    };
+}
+
+fn previewCell(cp: u21, cell: [CELL_H]u8) void {
+    std.debug.print("U+{X:0>4}:\n", .{cp});
+    for (cell) |byte| {
+        var col: u32 = 0;
+        var line = [_]u8{'.'} ** CELL_W;
+        while (col < CELL_W) : (col += 1) {
+            if (byte & (@as(u8, 0x80) >> @intCast(col)) != 0) line[col] = '#';
+        }
+        std.debug.print("  {s}\n", .{line});
+    }
+}

--- a/tools/ttf2bdf.zig
+++ b/tools/ttf2bdf.zig
@@ -1,8 +1,8 @@
 //! Rasterize a TrueType (`glyf`-outline) font into a fixed-cell, 1-bit BDF
 //! bitmap font for zt. Pure Zig, no external dependencies.
 //!
-//! Usage: ttf2bdf <input.ttf> <output.bdf> [--ppem N] [--baseline B]
-//!                [--xoff X] [--preview]
+//! Usage: ttf2bdf <input.ttf> <output.bdf> [--baseline B]
+//!                [--xscale S] [--yscale S] [--xoff X] [--preview]
 //!
 //! Each glyph is rendered into a CELL_W x CELL_H monochrome cell, baseline-
 //! aligned, MSB-first packed rows (matching zt's renderer and bdf2blob). Only
@@ -39,13 +39,23 @@ const Xform = struct {
     }
 };
 
+fn requireBytes(d: []const u8, o: usize, n: usize) void {
+    if (o > d.len or n > d.len - o) {
+        std.debug.print("error: invalid font data: need {d} bytes at offset {d}, file has {d} bytes\n", .{ n, o, d.len });
+        std.process.exit(1);
+    }
+}
+
 fn rdU16(d: []const u8, o: usize) u16 {
+    requireBytes(d, o, 2);
     return std.mem.readInt(u16, d[o..][0..2], .big);
 }
 fn rdI16(d: []const u8, o: usize) i16 {
+    requireBytes(d, o, 2);
     return std.mem.readInt(i16, d[o..][0..2], .big);
 }
 fn rdU32(d: []const u8, o: usize) u32 {
+    requireBytes(d, o, 4);
     return std.mem.readInt(u32, d[o..][0..4], .big);
 }
 
@@ -69,11 +79,22 @@ const Font = struct {
     }
 };
 
+fn contourPoint(contours: []const []Pt, point_index: i32) ?*Pt {
+    if (point_index < 0) return null;
+    var remaining: usize = @intCast(point_index);
+    for (contours) |pts| {
+        if (remaining < pts.len) return &pts[remaining];
+        remaining -= pts.len;
+    }
+    return null;
+}
+
 fn findTable(d: []const u8, tag: *const [4]u8) ?usize {
     const num = rdU16(d, 4);
     var i: usize = 0;
     while (i < num) : (i += 1) {
         const rec = 12 + i * 16;
+        requireBytes(d, rec, 16);
         if (std.mem.eql(u8, d[rec..][0..4], tag)) return rdU32(d, rec + 8);
     }
     return null;
@@ -89,6 +110,7 @@ fn collectGlyph(
     contours: *std.ArrayList([]Pt),
 ) !void {
     if (depth > 8) return;
+    if (gid >= font.num_glyphs) fatal("cmap references glyph id beyond maxp numGlyphs");
     const start = font.locaAt(gid);
     const end = font.locaAt(gid + 1);
     if (end <= start) return; // empty glyph (e.g. space)
@@ -211,8 +233,23 @@ fn collectGlyph(
             if (comp_flags & 0x0002 != 0) { // ARGS_ARE_XY_VALUES
                 cxf.e = @floatFromInt(arg1);
                 cxf.f = @floatFromInt(arg2);
+                try collectGlyph(font, comp_gid, xf.compose(cxf), depth + 1, a, contours);
+            } else {
+                var component_contours: std.ArrayList([]Pt) = .empty;
+                try collectGlyph(font, comp_gid, xf.compose(cxf), depth + 1, a, &component_contours);
+
+                const parent_anchor = contourPoint(contours.items, arg1) orelse fatal("invalid composite parent point index");
+                const child_anchor = contourPoint(component_contours.items, arg2) orelse fatal("invalid composite component point index");
+                const dx = parent_anchor.x - child_anchor.x;
+                const dy = parent_anchor.y - child_anchor.y;
+                for (component_contours.items) |pts| {
+                    for (pts) |*p| {
+                        p.x += dx;
+                        p.y += dy;
+                    }
+                }
+                try contours.appendSlice(a, component_contours.items);
             }
-            try collectGlyph(font, comp_gid, xf.compose(cxf), depth + 1, a, contours);
             if (comp_flags & 0x0020 == 0) break; // no MORE_COMPONENTS
         }
     }
@@ -349,7 +386,7 @@ pub fn main(init: std.process.Init) !void {
     const input_path = ait.next();
     const output_path = ait.next();
     if (input_path == null or output_path == null) {
-        std.debug.print("Usage: {s} <input.ttf> <output.bdf> [--ppem N] [--baseline B] [--xoff X] [--preview]\n", .{prog});
+        std.debug.print("Usage: {s} <input.ttf> <output.bdf> [--baseline B] [--xscale S] [--yscale S] [--xoff X] [--preview]\n", .{prog});
         std.process.exit(1);
     }
     var opts = Opts{};
@@ -357,19 +394,27 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--preview")) {
             opts.preview = true;
         } else if (std.mem.eql(u8, arg, "--xscale")) {
-            opts.xscale = std.fmt.parseFloat(f64, ait.next() orelse "0") catch null;
+            const val = ait.next() orelse fatal("missing value for --xscale");
+            opts.xscale = std.fmt.parseFloat(f64, val) catch fatal("invalid value for --xscale");
         } else if (std.mem.eql(u8, arg, "--yscale")) {
-            opts.yscale = std.fmt.parseFloat(f64, ait.next() orelse "0") catch null;
+            const val = ait.next() orelse fatal("missing value for --yscale");
+            opts.yscale = std.fmt.parseFloat(f64, val) catch fatal("invalid value for --yscale");
         } else if (std.mem.eql(u8, arg, "--baseline")) {
-            opts.baseline = std.fmt.parseFloat(f64, ait.next() orelse "0") catch null;
+            const val = ait.next() orelse fatal("missing value for --baseline");
+            opts.baseline = std.fmt.parseFloat(f64, val) catch fatal("invalid value for --baseline");
         } else if (std.mem.eql(u8, arg, "--xoff")) {
-            opts.xoff = std.fmt.parseFloat(f64, ait.next() orelse "0") catch 0;
+            const val = ait.next() orelse fatal("missing value for --xoff");
+            opts.xoff = std.fmt.parseFloat(f64, val) catch fatal("invalid value for --xoff");
+        } else {
+            std.debug.print("error: unknown option '{s}'\n", .{arg});
+            std.process.exit(1);
         }
     }
 
     const cwd = std.Io.Dir.cwd();
     const data = try cwd.readFileAlloc(io, input_path.?, a, .unlimited);
 
+    requireBytes(data, 0, 4);
     if (rdU32(data, 0) != 0x00010000 and !std.mem.eql(u8, data[0..4], "true")) {
         std.debug.print("error: not a TrueType (glyf) font; CFF/OTF is unsupported\n", .{});
         std.process.exit(1);
@@ -418,16 +463,20 @@ pub fn main(init: std.process.Init) !void {
         \\
     , .{ CELL_W, CELL_H, -ydescent_rows, map.count() });
 
-    var edges: std.ArrayList(Edge) = .empty;
-    var contours: std.ArrayList([]Pt) = .empty;
-
     var rendered: u32 = 0;
     var it = map.iterator();
     while (it.next()) |entry| {
         const cp = entry.key_ptr.*;
         const gid = entry.value_ptr.*;
+        if (gid >= font.num_glyphs) fatal("cmap references glyph id beyond maxp numGlyphs");
 
-        contours.clearRetainingCapacity();
+        var glyph_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer glyph_arena.deinit();
+        const ga = glyph_arena.allocator();
+
+        var contours: std.ArrayList([]Pt) = .empty;
+        var edges: std.ArrayList(Edge) = .empty;
+
         // Unit -> pixel transform baked into the collected contour points.
         const xf = Xform{
             .a = scale_x,
@@ -435,11 +484,10 @@ pub fn main(init: std.process.Init) !void {
             .e = opts.xoff,
             .f = baseline,
         };
-        try collectGlyph(font, gid, xf, 0, a, &contours);
+        try collectGlyph(font, gid, xf, 0, ga, &contours);
 
-        edges.clearRetainingCapacity();
-        for (contours.items) |c| try flattenContour(c, a, &edges);
-        const cell = try rasterize(edges.items, a);
+        for (contours.items) |c| try flattenContour(c, ga, &edges);
+        const cell = try rasterize(edges.items, ga);
 
         try out.print(a,
             \\STARTCHAR U+{X:0>4}


### PR DESCRIPTION
## **User description**
## Summary

Adds `-Dfont` to embed a custom font at build time, instead of the default blob. Both **BDF** (bitmap) and **TTF** (TrueType outline) inputs are supported, converted by **pure-Zig host tools with no external dependencies** (no FreeType, no FontForge). The runtime stays zero-dependency — only the resulting binary blob is embedded, exactly as with the default font.

Addresses the outline-font request in #30.

## What's included

- **`tools/bdf2blob.zig`** — BDF → zt binary blob (Zig port of zt-fonts' `bdf2blob.py`; byte-identical output).
- **`tools/ttf2bdf.zig`** — rasterizes TrueType (`glyf`) outlines into a 1-bit 8×16 BDF:
  - `glyf`/`loca` parsing incl. composite glyphs, `cmap` format 4, quadratic bézier flattening, nonzero-winding scanline fill (MSB-first, matching the renderer).
  - Scaling derived from font metrics: advance width → cell width, ascent/descent → cell height, baseline at ascent.
  - Tuning flags: `--baseline`, `--xscale`, `--yscale`, `--xoff`, `--preview`.
- **`build.zig`** — `-Dfont` routing: `.ttf` → `ttf2bdf` → `bdf2blob`, `.bdf` → `bdf2blob`. Embedded via the `font_blob` anonymous import. OTF/CFF is rejected with a clear message (use `.ttf`).
- **README** — experimental "Custom fonts" section + [Topaz NG](https://codeberg.org/ideasman42/font-topaz-ng) example.
- Version bump to **0.9.0** (and aligned `build.zig.zon`, previously 0.7.1).

## Verification

Validated end-to-end with Topaz NG (`TopazNG_Code-Regular.ttf`, 8×16 native cell):

- `ttf2bdf` rasterizes **502 glyphs** correctly (letters, digits, box-drawing connect/tile, vertical bars full-height) — eyeballed via `--preview`.
- `zig build -Dfont=TopazNG_Code-Regular.ttf` builds zt with the font embedded.

## Test plan

- [x] `zig build -Dbackend=fbdev` (default font) — green
- [x] `zig build test -Dbackend=fbdev` — green
- [x] `zig build -Dbackend=fbdev -Dfont=…/TopazNG_Code-Regular.ttf` — green, 502 glyphs embedded
- [x] `zig build -Dbackend=fbdev -Dfont=…/font.bdf` — green
- [x] `zig fmt --check` on `build.zig`, `tools/*.zig` — clean
- [ ] Visual check rendering Topaz NG in a real X11/Wayland session

## Notes

- **OTF (CFF) is not supported** — Topaz NG ships both; use the `.ttf` variant.
- 1-bit monochrome at the fixed 8×16 cell (no antialiasing, no color emoji) — consistent with zt's existing rendering.
- The font file itself is not vendored (external/licensing); users download it and pass `-Dfont`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 実験的なカスタムフォント埋め込みオプションを追加。ビルド時に外部フォントを指定して組み込みフォントを差し替え可能（TTF はビルド時にセル向けの1-bitビットマップへ変換され埋め込まれます）。
  * ドキュメントに利用例と制限事項（ビットマップレンダリングのみ、フォールバック無し等）を追記。

* **Chores**
  * パッケージ/ビルドのバージョンを 0.9.0 に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Embed custom BDF or TTF fonts at build time**

### What Changed
- You can now build the app with a custom font instead of the bundled default by passing `-Dfont`
- BDF fonts are packed directly into the embedded font blob
- TTF fonts are rasterized into the fixed 8×16 bitmap font at build time before being embedded
- Builds now reject unsupported font files with a clear error, and the default embedded font is still used when `-Dfont` is not set
- The README now documents custom font builds and marks the feature as experimental

### Impact
`✅ Custom fonts without runtime setup`
`✅ Fewer build-time font failures`
`✅ Clearer font format errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
